### PR TITLE
Fix underline position and remove Inbox code

### DIFF
--- a/spec/HighlightGeneratorSpec.js
+++ b/spec/HighlightGeneratorSpec.js
@@ -42,9 +42,8 @@ describe('HighlightGenerator', function () {
     it('generates a node that is styled and positioned', function () {
       var rect = {top: 2, left: 2, height: 10};
       var parentRect = {top: 1, left: 1, height:1};
-      var fieldType = 'compose';
 
-      var node = HighlightGenerator.highlightMatch(rect, parentRect, fieldType);
+      var node = HighlightGenerator.highlightMatch(rect, parentRect);
       expect(node).toBeDefined();
       expect(node.nodeName).toEqual('DIV');
       expect(node.style.top).toEqual('11px');
@@ -60,11 +59,10 @@ describe('HighlightGenerator', function () {
   });
 
   describe('#transformCoordinatesRelativeToParent', function () {
-    var scroll = {top: 0, left: 0};
     var subject = function () {
       var rect = {top: 30, left: 2, height: 10};
       var parentRect = {top: 1, left: 1, height: 100};
-      return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll);
+      return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect);
     };
 
     it('returns the top position relative to the parent top position', function () {
@@ -72,16 +70,6 @@ describe('HighlightGenerator', function () {
     });
 
     it('returns the left position relative to the parent left position', function () {
-      expect(subject().left).toBeCloseTo(1);
-    });
-
-    it('does not offset the top position when the window is vertically scrolled', function () {
-      scroll = {top: 10, left: 0};
-      expect(subject().top).toBeCloseTo(39);
-    });
-
-    it('does not offset the left position when the window is horizontally scrolled', function () {
-      scroll = {top: 0, left: 10};
       expect(subject().left).toBeCloseTo(1);
     });
   });

--- a/spec/HighlightGeneratorSpec.js
+++ b/spec/HighlightGeneratorSpec.js
@@ -48,7 +48,7 @@ describe('HighlightGenerator', function () {
       expect(node).toBeDefined();
       expect(node.nodeName).toEqual('DIV');
       expect(node.style.top).toEqual('11px');
-      expect(node.style.left).toEqual('3px');
+      expect(node.style.left).toEqual('1px');
     });
   });
 
@@ -64,28 +64,28 @@ describe('HighlightGenerator', function () {
       describe('and field type is compose', function () {
         var scroll = {top: 0, left: 0};
         var subject = function () {
-          var rect = {top: 2, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 1};
+          var rect = {top: 30, left: 2, height: 10};
+          var parentRect = {top: 1, left: 1, height: 100};
           var fieldType = 'compose';
           return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
         };
 
-        it('returns the top position relative to the parent top position and offset by 90% of the rectangle', function () {
-          expect(subject().top).toBeCloseTo(11);
+        it('returns the top position relative to the parent top position', function () {
+          expect(subject().top).toBeCloseTo(39);
         });
 
         it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(3);
+          expect(subject().left).toBeCloseTo(1);
         });
 
-        it('offsets the top position when the window is vertically scrolled', function () {
+        it('does not offset the top position when the window is vertically scrolled', function () {
           scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(11);
+          expect(subject().top).toBeCloseTo(39);
         });
 
         it('offsets the left position when the window is horizontally scrolled', function () {
           scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(13);
+          expect(subject().left).toBeCloseTo(11);
         });
       });
 
@@ -161,7 +161,7 @@ describe('HighlightGenerator', function () {
         });
 
         it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(3);
+          expect(subject().left).toBeCloseTo(1);
         });
 
         it('offsets the top position when the window is vertically scrolled', function () {
@@ -171,7 +171,7 @@ describe('HighlightGenerator', function () {
 
         it('offsets the left position when the window is horizontally scrolled', function () {
           scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(13);
+          expect(subject().left).toBeCloseTo(11);
         });
       });
 
@@ -225,8 +225,8 @@ describe('HighlightGenerator', function () {
       expect(node.style.width).toEqual('20px');
     });
 
-    it('sets the height to 25% of the height of the rectangle', function () {
-      expect(node.style.height).toEqual('3px');
+    it('sets the height to 20% of the height of the rectangle', function () {
+      expect(node.style.height).toEqual('2.4px');
     });
 
     it('sets padding', function () {

--- a/spec/HighlightGeneratorSpec.js
+++ b/spec/HighlightGeneratorSpec.js
@@ -60,148 +60,29 @@ describe('HighlightGenerator', function () {
   });
 
   describe('#transformCoordinatesRelativeToParent', function () {
-    describe('when provider is Gmail', function () {
-      describe('and field type is compose', function () {
-        var scroll = {top: 0, left: 0};
-        var subject = function () {
-          var rect = {top: 30, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 100};
-          var fieldType = 'compose';
-          return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
-        };
+    var scroll = {top: 0, left: 0};
+    var subject = function () {
+      var rect = {top: 30, left: 2, height: 10};
+      var parentRect = {top: 1, left: 1, height: 100};
+      return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll);
+    };
 
-        it('returns the top position relative to the parent top position', function () {
-          expect(subject().top).toBeCloseTo(39);
-        });
-
-        it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(1);
-        });
-
-        it('does not offset the top position when the window is vertically scrolled', function () {
-          scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(39);
-        });
-
-        it('offsets the left position when the window is horizontally scrolled', function () {
-          scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(11);
-        });
-      });
-
-      describe('and field type is reply', function () {
-        var scroll = {top: 0, left: 0};
-        var subject = function () {
-          var rect = {top: 2, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 1};
-          var fieldType = 'reply';
-          return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
-        };
-
-        it('returns the top position relative to the parent top position and offset by 90% of the rectangle', function () {
-          expect(subject().top).toBeCloseTo(1.12);
-        });
-
-        it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(1);
-        });
-
-        it('offsets the top position when the window is vertically scrolled', function () {
-          scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(1.12);
-        });
-
-        it('offsets the left position when the window is horizontally scrolled', function () {
-          scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(11);
-        });
-      });
-
-      describe('and field type is forward', function () {
-        var scroll = {top: 0, left: 0};
-        var subject = function () {
-          var rect = {top: 2, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 1};
-          var fieldType = 'forward';
-          return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
-        };
-
-        it('returns the top position relative to the parent top position and offset by 90% of the rectangle', function () {
-          expect(subject().top).toBeCloseTo(1.02);
-        });
-
-        it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(1);
-        });
-
-        it('offsets the top position when the window is vertically scrolled', function () {
-          scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(1.02);
-        });
-
-        it('offsets the left position when the window is horizontally scrolled', function () {
-          scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(11);
-        });
-      });
+    it('returns the top position relative to the parent top position', function () {
+      expect(subject().top).toBeCloseTo(39);
     });
 
-    describe('when provider is Inbox', function () {
-      describe('and field type is compose', function () {
-        var scroll = {top: 0, left: 0};
-        var subject = function () {
-          var rect = {top: 2, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 1};
-          var fieldType = 'compose';
-          return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
-        };
+    it('returns the left position relative to the parent left position', function () {
+      expect(subject().left).toBeCloseTo(1);
+    });
 
-        it('returns the top position relative to the parent top position and offset by 90% of the rectangle', function () {
-          expect(subject().top).toBeCloseTo(11);
-        });
+    it('does not offset the top position when the window is vertically scrolled', function () {
+      scroll = {top: 10, left: 0};
+      expect(subject().top).toBeCloseTo(39);
+    });
 
-        it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(1);
-        });
-
-        it('offsets the top position when the window is vertically scrolled', function () {
-          scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(11);
-        });
-
-        it('offsets the left position when the window is horizontally scrolled', function () {
-          scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(11);
-        });
-      });
-
-      describe('and field type is reply', function () {
-        var scroll = {top: 0, left: 0};
-        var subject = function () {
-          var rect = {top: 2, left: 2, height: 10};
-          var parentRect = {top: 1, left: 1, height: 1};
-          var fieldType = 'reply';
-          return HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
-        };
-
-        it('returns the top position relative to the parent top position and offset by 90% of the rectangle', function () {
-          expect(subject().top).toBeCloseTo(1.12);
-        });
-
-        it('returns the left position relative to the parent left position', function () {
-          expect(subject().left).toBeCloseTo(1);
-        });
-
-        it('offsets the top position when the window is vertically scrolled', function () {
-          scroll = {top: 10, left: 0};
-          expect(subject().top).toBeCloseTo(1.12);
-        });
-
-        it('offsets the left position when the window is horizontally scrolled', function () {
-          scroll = {top: 0, left: 10};
-          expect(subject().left).toBeCloseTo(11);
-        });
-      });
+    it('does not offset the left position when the window is horizontally scrolled', function () {
+      scroll = {top: 0, left: 10};
+      expect(subject().left).toBeCloseTo(1);
     });
   });
 

--- a/spec/HighlightGeneratorSpec.js
+++ b/spec/HighlightGeneratorSpec.js
@@ -1,8 +1,4 @@
 describe('HighlightGenerator', function () {
-  beforeEach(function() {
-    var host = spyOn(HighlightGenerator, 'getHostname').and.returnValue('mail.google.com')
-  });
-
   describe('#highlightMatches', function () {
     var warningClass = 'test-warning';
     var message = 'test';

--- a/spec/WarningCheckerSpec.js
+++ b/spec/WarningCheckerSpec.js
@@ -21,14 +21,14 @@ describe('WarningChecker', function() {
       var generatorSpy = spyOn(HighlightGenerator, 'highlightMatches');
       var content = 'test just test';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture, 'just', 'warning message', 'compose gmail');
-      expect(generatorSpy).toHaveBeenCalledWith('warning message', 'jns-warning', 'compose gmail');
+      checker.addWarning($fixture, 'just', 'warning message');
+      expect(generatorSpy).toHaveBeenCalledWith('warning message', 'jns-warning');
     });
 
     it('adds a warning for a single keyword', function() {
       var content = 'test just test';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'just', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'just', 'warning message');
       expect($fixture.find('div.jns-warning').length).toEqual(1);
     });
 
@@ -42,35 +42,35 @@ describe('WarningChecker', function() {
     it('adds multiple warnings when keyword is matched multiple times', function() {
       var content = 'test just test just test';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'just', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'just', 'warning message');
       expect($fixture.find('div.jns-warning').length).toEqual(2);
     });
 
     it('adds a title element to provide a message in a tooltip', function() {
       var content = 'test just test sorry test';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'just', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'just', 'warning message');
       expect($fixture.find('div.jns-warning')[0].title).toEqual('warning message');
     });
 
     it('matches case insensitive', function() {
       var content = 'jUsT kidding';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'just', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'just', 'warning message');
       expect($fixture.find('div.jns-warning').length).toEqual(1);
     });
 
     it('catches keywords with punctuation', function() {
       var content = 'just. test';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'just', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'just', 'warning message');
       expect($fixture.find('div.jns-warning').length).toEqual(1);
     });
 
     it('matches phrases', function() {
       var content = 'my cat is so sorry because of you';
       var $fixture = setFixtures(content);
-      checker.addWarning($fixture[0], 'so sorry', 'warning message', 'compose');
+      checker.addWarning($fixture[0], 'so sorry', 'warning message');
       expect($fixture.find('div.jns-warning').length).toEqual(1);
     });
   });
@@ -103,7 +103,7 @@ describe('WarningChecker', function() {
       it('adds warnings to all keywords', function() {
         var content = 'I am just so sorry. Yes, just.';
         var $fixture = setFixtures(content);
-        checker.addWarnings($fixture[0], 'compose');
+        checker.addWarnings($fixture[0]);
         expect($fixture.find('div.warning1').length).toEqual(3);
         expect($fixture.find('div.warning1[title="test"]').length).toEqual(2);
         expect($fixture.find('div.warning1[title="test 2"]').length).toEqual(1);

--- a/spec/WarningCheckerSpec.js
+++ b/spec/WarningCheckerSpec.js
@@ -1,11 +1,9 @@
 describe('WarningChecker', function() {
   describe('.addWarning', function() {
     var checker;
-    var host;
 
     beforeEach(function() {
       checker = new WarningChecker({});
-      host = spyOn(HighlightGenerator, 'getHostname').and.returnValue('mail.google.com')
     });
 
     it('delegates to domRegexpMatch', function() {
@@ -89,7 +87,6 @@ describe('WarningChecker', function() {
           ],
         }
       );
-      host = spyOn(HighlightGenerator, 'getHostname').and.returnValue('mail.google.com')
     });
 
     describe('.addWarnings', function() {

--- a/src/HighlightGenerator.js
+++ b/src/HighlightGenerator.js
@@ -41,7 +41,3 @@ HighlightGenerator.setNodeStyle = function positionNode(node, rect, coords) {
   node.style.position = 'absolute';
   node.style.padding = '0px';
 };
-
-HighlightGenerator.getHostname = function() {
-  return document.location.hostname;
-};

--- a/src/HighlightGenerator.js
+++ b/src/HighlightGenerator.js
@@ -37,7 +37,7 @@ HighlightGenerator.transformCoordinatesRelativeToParent = function transformCoor
   } else if (HighlightGenerator.getHostname() === 'mail.google.com') {
     fieldType = fieldType + ' gmail';
     if (fieldType === 'compose gmail') {
-      coords.top = (rect.top - parentRect.top + rect.height - 5);
+      coords.top = (rect.top - parentRect.top + rect.height);
       coords.left = (rect.left + scroll.left - parentRect.left + 2);
       return coords;
     } else if (fieldType === 'reply gmail') {
@@ -45,7 +45,7 @@ HighlightGenerator.transformCoordinatesRelativeToParent = function transformCoor
       coords.left = (rect.left + scroll.left - parentRect.left);
       return coords;
     } else if (fieldType === 'forward gmail') {
-      coords.top = (rect.top - parentRect.top + (parentRect.height * 0.052));
+      coords.top = (rect.top - parentRect.top + (parentRect.height * 0.02));
       coords.left = (rect.left + scroll.left - parentRect.left);
       return coords;
     }

--- a/src/HighlightGenerator.js
+++ b/src/HighlightGenerator.js
@@ -19,7 +19,7 @@ HighlightGenerator.highlightMatch = function highlightMatch(rect, parentRect, fi
   var scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
   var scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft;
   var scroll = {top: scrollTop, left: scrollLeft};
-  var coords = HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType);
+  var coords = HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll);
   HighlightGenerator.setNodeStyle(highlightNode, rect, coords);
   return highlightNode;
 };
@@ -30,26 +30,9 @@ HighlightGenerator.generateHighlightNode = function generateHighlightNode() {
 
 HighlightGenerator.transformCoordinatesRelativeToParent = function transformCoordinatesRelativeToParent(rect, parentRect, scroll, fieldType) {
   var coords = {};
-  if (HighlightGenerator.getHostname() === 'inbox.google.com') {
-    coords.top = (rect.top - parentRect.top + (rect.height * 0.6));
-    coords.left = (rect.left + scroll.left - parentRect.left);
-    return coords;
-  } else if (HighlightGenerator.getHostname() === 'mail.google.com') {
-    fieldType = fieldType + ' gmail';
-    if (fieldType === 'compose gmail') {
-      coords.top = (rect.top - parentRect.top + rect.height);
-      coords.left = (rect.left + scroll.left - parentRect.left);
-      return coords;
-    } else if (fieldType === 'reply gmail') {
-      coords.top = (rect.top - parentRect.top + (parentRect.height * 0.12));
-      coords.left = (rect.left + scroll.left - parentRect.left);
-      return coords;
-    } else if (fieldType === 'forward gmail') {
-      coords.top = (rect.top - parentRect.top + (parentRect.height * 0.02));
-      coords.left = (rect.left + scroll.left - parentRect.left);
-      return coords;
-    }
-  }
+  coords.top = (rect.top - parentRect.top + rect.height);
+  coords.left = (rect.left - parentRect.left);
+  return coords;
 };
 
 HighlightGenerator.setNodeStyle = function positionNode(node, rect, coords) {

--- a/src/HighlightGenerator.js
+++ b/src/HighlightGenerator.js
@@ -1,12 +1,12 @@
 var HighlightGenerator = window.HighlightGenerator = {};
 
-HighlightGenerator.highlightMatches = function highlightMatches(message, warningClass, fieldType) {
+HighlightGenerator.highlightMatches = function highlightMatches(message, warningClass) {
   return function (currMatch, rangeToHighlight) {
     var parentNode = this;
     var parentRect = parentNode.getBoundingClientRect();
     var rectsToHighlight = rangeToHighlight.getClientRects();
     for (var i = 0; i < rectsToHighlight.length; i++) {
-      var highlightNode = HighlightGenerator.highlightMatch(rectsToHighlight[i], parentRect, fieldType);
+      var highlightNode = HighlightGenerator.highlightMatch(rectsToHighlight[i], parentRect);
       highlightNode.title = message;
       highlightNode.className = warningClass;
       parentNode.appendChild(highlightNode);
@@ -14,12 +14,9 @@ HighlightGenerator.highlightMatches = function highlightMatches(message, warning
   }
 };
 
-HighlightGenerator.highlightMatch = function highlightMatch(rect, parentRect, fieldType) {
+HighlightGenerator.highlightMatch = function highlightMatch(rect, parentRect) {
   var highlightNode = HighlightGenerator.generateHighlightNode();
-  var scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
-  var scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft;
-  var scroll = {top: scrollTop, left: scrollLeft};
-  var coords = HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect, scroll);
+  var coords = HighlightGenerator.transformCoordinatesRelativeToParent(rect, parentRect);
   HighlightGenerator.setNodeStyle(highlightNode, rect, coords);
   return highlightNode;
 };

--- a/src/HighlightGenerator.js
+++ b/src/HighlightGenerator.js
@@ -38,7 +38,7 @@ HighlightGenerator.transformCoordinatesRelativeToParent = function transformCoor
     fieldType = fieldType + ' gmail';
     if (fieldType === 'compose gmail') {
       coords.top = (rect.top - parentRect.top + rect.height);
-      coords.left = (rect.left + scroll.left - parentRect.left + 2);
+      coords.left = (rect.left + scroll.left - parentRect.left);
       return coords;
     } else if (fieldType === 'reply gmail') {
       coords.top = (rect.top - parentRect.top + (parentRect.height * 0.12));
@@ -56,7 +56,7 @@ HighlightGenerator.setNodeStyle = function positionNode(node, rect, coords) {
   node.style.top = coords.top + 'px';
   node.style.left = coords.left + 'px';
   node.style.width = (rect.width) + 'px';
-  node.style.height = (rect.height * 0.25) + 'px';
+  node.style.height = (rect.height * 0.2) + 'px';
   node.style.zIndex = 10;
   node.style.position = 'absolute';
   node.style.padding = '0px';

--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -29,7 +29,6 @@ var observer = new MutationObserver(function(mutation) {
 
 function checkForWarnings(warningChecker, mutation) {
   var target
-  var fieldType;
   target = document.querySelector('div[contentEditable=true]');
 
   document.querySelectorAll('div[contentEditable=true]').forEach((field) => {
@@ -44,29 +43,8 @@ function checkForWarnings(warningChecker, mutation) {
     });
   });
 
-  fieldType = null;
-  // Inbox
-  if (target.getAttribute('aria-label') === 'Reply' || target.getAttribute('aria-label') === 'Reply to all') {
-    fieldType = 'reply';
-  } else if (target.getAttribute('aria-label') === 'Body') {
-    fieldType = 'compose';
-  }
-  //Gmail
-  if (target.getAttribute('aria-label') === 'Message Body') {
-    Array.from(target.children).forEach(function(child) {
-      if (child.className ==='gmail_quote') {
-        fieldType = 'forward';
-      }
-    });
-    if (fieldType != 'forward' && target.nextSibling && target.nextSibling.className === 'aO8') {
-      fieldType = 'reply';
-    }
-    if (fieldType != 'forward' && fieldType != 'reply') {
-      fieldType = 'compose';
-    }
-  }
   warningChecker.removeWarnings(target.parentNode);
-  warningChecker.addWarnings(target.parentNode, fieldType);
+  warningChecker.addWarnings(target.parentNode);
   removeWarningsOnBlur(target.parentNode);
 }
 

--- a/src/WarningChecker.js
+++ b/src/WarningChecker.js
@@ -4,17 +4,17 @@ function WarningChecker(options) {
   this.warningClass = options.warningClass || 'jns-warning';
 }
 
-WarningChecker.prototype.addWarning = function addWarning(node, keyword, message, fieldType) {
+WarningChecker.prototype.addWarning = function addWarning(node, keyword, message) {
   'use strict';
   var pattern = new RegExp('\\b(' + keyword + ')\\b', 'ig');
-  domRegexpMatch(node, pattern, HighlightGenerator.highlightMatches(message, this.warningClass, fieldType));
+  domRegexpMatch(node, pattern, HighlightGenerator.highlightMatches(message, this.warningClass));
 };
 
-WarningChecker.prototype.addWarnings = function addWarnings(node, fieldType) {
+WarningChecker.prototype.addWarnings = function addWarnings(node) {
   'use strict';
   var _this = this;
   this.warnings.forEach(function(warning) {
-    _this.addWarning(node, warning.keyword, warning.message, fieldType);
+    _this.addWarning(node, warning.keyword, warning.message);
   });
 };
 


### PR DESCRIPTION
This PR focuses on fixing the issues with the position of the underlines for various edge cases, including:

* long emails with multiple line breaks
* small windows with the editable area scrolled horizontally or vertically
* different positioning in forward vs. reply

As part of this work, I unified how underline position calculation is done (so compose, reply, and forward all work the same way) and removed the Inbox specific code.  The tests all pass now.

There are still two outstanding issues related to underline positioning:

* If the window is resized while the underlines are shown, the underlines will be out of place until the text is changed again
* Adding a line break between paragraphs does not trigger the underline position to be recalculated, so this can cause the underlines to be mispositioned until a character is typed into the edit box.

These issues are related to a different area of the code, so I'd like to handle them separately.

@ProfJanetDavis @steveatdm @perfetti Please let me know what you think of the changes.  If you'd like any tweaks made to the line position (such as moving it closer to the word), please let me know.

Fixes #54  
Fixes #55 