### PR TITLE
Detect Child List Mutations

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -19,11 +19,13 @@
   <script src="src/Warnings.js"></script>
   <script src="src/WarningChecker.js"></script>
   <script src="src/HighlightGenerator.js"></script>
+  <script src="src/JustNotSorry.js"></script>
 
   <!-- include spec files here... -->
   <script src="spec/WarningCheckerSpec.js"></script>
   <script src="spec/WarningsSpec.js"></script>
   <script src="spec/HighlightGeneratorSpec.js"></script>
+  <script src="spec/JustNotSorrySpec.js"></script>
 
 </head>
 

--- a/spec/JustNotSorrySpec.js
+++ b/spec/JustNotSorrySpec.js
@@ -1,0 +1,71 @@
+describe('JustNotSorry', function () {
+  function generateEditableDiv(id) {
+    let editableDiv = document.createElement('DIV');
+    editableDiv.setAttribute('id', id);
+    editableDiv.setAttribute('contentEditable', 'true');
+    document.body.appendChild(editableDiv);
+  }
+
+  function dispatchEventOnElement(target, eventName) {
+    let event = new Event(eventName, {});
+    target.dispatchEvent(event);
+  }
+
+  beforeAll(function() {
+      generateEditableDiv('div-1');
+      generateEditableDiv('div-2');
+      generateEditableDiv('div-3');
+  });
+
+  describe('#getEditableDivs', function() {
+    it('returns an array of all content editable divs within the document', function () {
+      let divs = getEditableDivs();
+      expect(divs.length).toEqual(3);
+    });
+  });
+
+  describe('#addObserver', function() {
+    it('adds an observer on focus of an element', function () {
+      let target = document.getElementById('div-1');
+      spyOn(observer, 'observe');
+
+      target.addEventListener('focus', addObserver);
+      expect(observer.observe).not.toHaveBeenCalled();
+      dispatchEventOnElement(target, 'focus');
+      expect(observer.observe).toHaveBeenCalled();
+    });
+  });
+
+  describe('#removeObserver', function() {
+    it('disconnects the observer on blur of an element', function () {
+      let target = document.getElementById('div-2');
+      spyOn(observer, 'observe');
+      spyOn(observer, 'disconnect');
+
+      target.addEventListener('focus', addObserver);
+      dispatchEventOnElement(target, 'focus');
+      expect(observer.observe).toHaveBeenCalled();
+
+      target.addEventListener('blur', removeObserver);
+      dispatchEventOnElement(target, 'blur');
+      expect(observer.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  describe('#checkForWarnings', function() {
+    it('updates warnings each time input is triggered', function () {
+      let target = document.getElementById('div-3');
+      spyOn(window, 'checkForWarnings');
+      spyOn(warningChecker, 'addWarnings');
+      spyOn(warningChecker, 'removeWarnings');
+
+      target.addEventListener('input', checkForWarnings);
+      dispatchEventOnElement(target, 'input');
+      dispatchEventOnElement(target, 'input');
+      dispatchEventOnElement(target, 'input');
+
+      let callCount = window.checkForWarnings.calls.count();
+      expect(callCount).toEqual(3);
+    });
+  });
+});

--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -1,14 +1,11 @@
 'use strict';
 
 var warningChecker = new WarningChecker(WARNINGS);
-
 var editableDivCount = 0;
-
-var contentEditableDivs = [];
 
 var observer = new MutationObserver(function(mutations) {
   if (mutations[0]) {
-    mutations.forEach(function(mutation){
+    mutations.forEach(function(mutation) {
       if (mutation.type != 'characterData' && mutation.target.hasAttribute('contentEditable')) {
         id = mutation.target.id;
         if (id) {
@@ -53,7 +50,7 @@ var documentObserver = new MutationObserver(function(mutations) {
     editableDivCount = divCount;
     var id;
     if (mutations[0]) {
-      mutations.forEach(function(mutation){
+      mutations.forEach(function(mutation) {
         if (mutation.type == 'childList' && mutation.target.hasAttribute('contentEditable')) {
           id = mutation.target.id;
           if (id) {
@@ -69,4 +66,4 @@ function getEditableDivs() {
   return document.querySelectorAll('div[contentEditable=true]');
 }
 
-documentObserver.observe(document, {characterData: true, subtree: true, childList: true});
+documentObserver.observe(document, {subtree: true, childList: true});

--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -1,57 +1,72 @@
 'use strict';
 
-function removeWarningsOnBlur(target) {
-  target.onblur = function() {
-    warningChecker.removeWarnings(target);
-  }
-}
-
 var warningChecker = new WarningChecker(WARNINGS);
 
-var addTextEventListener = function(mutation) {
-  ['focus', 'input'].forEach(function(action) {
-    document.querySelector('div[contentEditable=true]').addEventListener(action, checkForWarnings(warningChecker, mutation))
-  });
-}
+var editableDivCount = 0;
 
-var removeTextEventListener = function() {
-  ['focus', 'input'].forEach(function(action) {
-    document.querySelector('div[contentEditable=true]').removeEventListener(action, checkForWarnings(warningChecker, action))
-  });
-}
+var contentEditableDivs = [];
 
-var observer = new MutationObserver(function(mutation) {
-  if (document.querySelector('div[contentEditable=true]')) {
-    addTextEventListener(mutation);
-    removeTextEventListener();
+var observer = new MutationObserver(function(mutations) {
+  if (mutations[0]) {
+    mutations.forEach(function(mutation){
+      if (mutation.type != 'characterData' && mutation.target.hasAttribute('contentEditable')) {
+        id = mutation.target.id;
+        if (id) {
+          var targetDiv = document.getElementById(id);
+          // generate input event to fire checkForWarnings again
+          var inputEvent = new Event('input', {
+              bubbles: true,
+              cancelable: true,
+          });
+          targetDiv.dispatchEvent(inputEvent);
+        }
+      }
+    });
   }
 });
 
-function checkForWarnings(warningChecker, mutation) {
-  var target
-  target = document.querySelector('div[contentEditable=true]');
-
-  document.querySelectorAll('div[contentEditable=true]').forEach((field) => {
-    var active = document.activeElement;
-    [field, active].reduce((a, b) => {
-      if (a != b) {
-        target = active;
-      }
-      if (target === null) {
-        target = field;
-      }
-    });
-  });
-
-  warningChecker.removeWarnings(target.parentNode);
-  warningChecker.addWarnings(target.parentNode);
-  removeWarningsOnBlur(target.parentNode);
+var addObserver = function() {
+  warningChecker.addWarnings(this.parentNode);
+  observer.observe(this, {characterData: true, subtree: true, childList: true,  attributes: true});
 }
 
-var loadObserver = setInterval(function() {
-  var editableDiv = document.querySelector('div[contentEditable=true]');
-  if (editableDiv != null) {
-    clearInterval(loadObserver);
-    observer.observe(editableDiv, {characterData: true, subtree: true, childList: true});
+var removeObserver = function() {
+  warningChecker.removeWarnings(this.parentNode);
+  observer.disconnect();
+}
+
+var checkForWarnings = function() {
+  warningChecker.removeWarnings(this.parentNode);
+  warningChecker.addWarnings(this.parentNode);
+}
+
+var applyEventListeners = function(id) {
+  var targetDiv = document.getElementById(id);
+  targetDiv.addEventListener('focus', addObserver);
+  targetDiv.addEventListener('input', checkForWarnings);
+  targetDiv.addEventListener('blur', removeObserver);
+}
+
+var documentObserver = new MutationObserver(function(mutations) {
+  var divCount = getEditableDivs().length;
+  if (divCount != editableDivCount) {
+    editableDivCount = divCount;
+    var id;
+    if (mutations[0]) {
+      mutations.forEach(function(mutation){
+        if (mutation.type == 'childList' && mutation.target.hasAttribute('contentEditable')) {
+          id = mutation.target.id;
+          if (id) {
+            applyEventListeners(id);
+          }
+        }
+      });
+    }
   }
-}, 1000);
+});
+
+function getEditableDivs() {
+  return document.querySelectorAll('div[contentEditable=true]');
+}
+
+documentObserver.observe(document, {characterData: true, subtree: true, childList: true});

--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -48,4 +48,10 @@ function checkForWarnings(warningChecker, mutation) {
   removeWarningsOnBlur(target.parentNode);
 }
 
-observer.observe(document, {characterData: true, subtree: true})
+var loadObserver = setInterval(function() {
+  var editableDiv = document.querySelector('div[contentEditable=true]');
+  if (editableDiv != null) {
+    clearInterval(loadObserver);
+    observer.observe(editableDiv, {characterData: true, subtree: true, childList: true});
+  }
+}, 1000);


### PR DESCRIPTION
These changes aim to resolve the issue of underlines not being re-rendered when line breaks are created. In addition to line breaks, it also now re-renders in the cases of hitting backspace (removing line breaks) and pasting text, as it handles hierarchy additions/removals in general.

The `childList` property was added to the observer's dictionary to capture those events, however it was not enough to change only that, as the scope was too large (document). The change limits the scope to the content editable div, and polls to add the observer once that editable div is found. There may be a more graceful way of handling it if there are other ideas, but it appears to function properly and be performant.