### PR TITLE
fix: fix issue where extension breaks sending emails

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Just Not Sorry -- the Gmail Plug-in",
   "short_name": "JustNotSorry",
   "author": "Steve Brudz, Manish Kakwani, Tami Reiss, and Eric Tillberg of Def Method",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "description": "A Gmail Plug-in that warns you when you write emails using words which undermine your message",
   "icons": { "16": "img/JustNotSorry-16.png",
              "48": "img/JustNotSorry-48.png",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "just-not-sorry",
   "description": "Gmail Plug-in that warns you when you write emails using words which undermine your message",
-  "version": "1.7.0",
+  "version": "1.6.2",
   "author": "Steve Brudz, Manish Kakwani, Tami Reiss, and Eric Tillberg of Def Method",
   "license": "MIT",
   "repository": "https://github.com/defmethodinc/just-not-sorry",

--- a/spec/JustNotSorrySpec.js
+++ b/spec/JustNotSorrySpec.js
@@ -34,6 +34,29 @@ describe('JustNotSorry', function () {
       dispatchEventOnElement(target, 'focus');
       expect(observer.observe).toHaveBeenCalled();
     });
+
+    describe('when a global id variable is set', function() {
+      beforeEach(function() {
+        window.id = 'test value';
+      });
+
+      afterEach(function() {
+        delete window.id;
+      });
+
+      it('keeps that global variable unchanged', function(done) {
+        const target = document.getElementById('div-2');
+        target.addEventListener('focus', addObserver);
+        dispatchEventOnElement(target, 'focus');
+
+        target.innerHTML = '<br/>';
+
+        setTimeout(function () {
+          expect(id).toEqual('test value');
+          done();
+        });
+      });
+    });
   });
 
   describe('#removeObserver', function() {

--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -6,8 +6,8 @@ var editableDivCount = 0;
 var observer = new MutationObserver(function(mutations) {
   if (mutations[0]) {
     mutations.forEach(function(mutation) {
-      if (mutation.type != 'characterData' && mutation.target.hasAttribute('contentEditable')) {
-        id = mutation.target.id;
+      if (mutation.type !== 'characterData' && mutation.target.hasAttribute('contentEditable')) {
+        var id = mutation.target.id;
         if (id) {
           var targetDiv = document.getElementById(id);
           // generate input event to fire checkForWarnings again
@@ -25,33 +25,33 @@ var observer = new MutationObserver(function(mutations) {
 var addObserver = function() {
   warningChecker.addWarnings(this.parentNode);
   observer.observe(this, {characterData: true, subtree: true, childList: true,  attributes: true});
-}
+};
 
 var removeObserver = function() {
   warningChecker.removeWarnings(this.parentNode);
   observer.disconnect();
-}
+};
 
 var checkForWarnings = function() {
   warningChecker.removeWarnings(this.parentNode);
   warningChecker.addWarnings(this.parentNode);
-}
+};
 
 var applyEventListeners = function(id) {
   var targetDiv = document.getElementById(id);
   targetDiv.addEventListener('focus', addObserver);
   targetDiv.addEventListener('input', checkForWarnings);
   targetDiv.addEventListener('blur', removeObserver);
-}
+};
 
 var documentObserver = new MutationObserver(function(mutations) {
   var divCount = getEditableDivs().length;
-  if (divCount != editableDivCount) {
+  if (divCount !== editableDivCount) {
     editableDivCount = divCount;
     var id;
     if (mutations[0]) {
       mutations.forEach(function(mutation) {
-        if (mutation.type == 'childList' && mutation.target.hasAttribute('contentEditable')) {
+        if (mutation.type === 'childList' && mutation.target.hasAttribute('contentEditable')) {
           id = mutation.target.id;
           if (id) {
             applyEventListeners(id);


### PR DESCRIPTION
This fixes an issue where, for display languages other than English, such as Magyar or Turkish, the extension highlights correctly but when you click Send on the email, nothing would happen.

Fixes #73

To reproduce the bug in v1.6.1, go to your GMail settings and change the display language to Magyar.  Then compose a new email and click the Send button.  The compose window closes but no email is sent and no feedback is provided by the UI.