### PR TITLE
ci(github): troubleshooting semantic release again

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           CI: true
       - name: Semantic Release
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           SSL_PASSPHRASE: ${{ secrets.SSL_PASSPHRASE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gpg --passphrase=$GPG_PASSPHRASE --batch --output /tmp/git_deploy_key --decrypt .git_deploy_key.enc
           chmod 600 /tmp/git_deploy_key


### PR DESCRIPTION
It appears that GITHUB_TOKEN is required even if using SSH.