### PR TITLE
107 outlook breaks warning check

### DIFF
--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -331,7 +331,6 @@ describe('JustNotSorry', () => {
         spy = jest
           .spyOn(instance, 'applyEventListeners')
           .mockImplementationOnce(() => {});
-        jest.spyOn(instance, 'getEditableDivs').mockReturnValue([1]);
       });
 
       it('should apply the event listeners', () => {

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -8,12 +8,12 @@ import domRegexpMatch from 'dom-regexp-match';
 
 export const WAIT_TIME_BEFORE_RECALC_WARNINGS = 500;
 const MAIL_BODY_DIV_ATTR = 'contenteditable';
+
 class JustNotSorry extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      editableDivCount: 0,
       warnings: [],
     };
 
@@ -31,38 +31,30 @@ class JustNotSorry extends Component {
   }
 
   handleContentEditableDivChange(mutations) {
-    let divCount = this.getEditableDivs().length;
-    if (divCount !== this.state.editableDivCount) {
-      this.setState({ editableDivCount: divCount });
-      if (mutations[0]) {
-        mutations
-          .filter(
-            (mutation) =>
-              mutation.type === 'childList' &&
-              mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
-          )
-          .forEach((mutation) => this.applyEventListeners(mutation.target));
-      }
-    }
+    mutations
+      .filter(
+        (mutation) =>
+          mutation.type === 'childList' &&
+          mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
+      )
+      .forEach((mutation) => this.applyEventListeners(mutation.target));
   }
 
   handleContentEditableContentInsert(mutations) {
-    if (mutations[0]) {
-      mutations
-        .filter(
-          (mutation) =>
-            mutation.type !== 'characterData' &&
-            mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
-        )
-        .forEach((mutation) => {
-          // generate input event to fire checkForWarnings again
-          let inputEvent = new Event('input', {
-            bubbles: true,
-            cancelable: true,
-          });
-          mutation.target.dispatchEvent(inputEvent);
+    mutations
+      .filter(
+        (mutation) =>
+          mutation.type !== 'characterData' &&
+          mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
+      )
+      .forEach((mutation) => {
+        // generate input event to fire checkForWarnings again
+        let inputEvent = new Event('input', {
+          bubbles: true,
+          cancelable: true,
         });
-    }
+        mutation.target.dispatchEvent(inputEvent);
+      });
   }
 
   checkForWarningsImpl(parentElement) {
@@ -103,10 +95,6 @@ class JustNotSorry extends Component {
     targetDiv.removeEventListener('focus', this.addObserver);
     targetDiv.addEventListener('focus', this.addObserver.bind(this));
     targetDiv.addEventListener('blur', this.removeObserver.bind(this));
-  }
-
-  getEditableDivs() {
-    return document.querySelectorAll('div[contentEditable=true]');
   }
 
   addWarning(node, pattern, message) {

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -7,7 +7,7 @@ import WARNING_MESSAGES from '../warnings/phrases.json';
 import domRegexpMatch from 'dom-regexp-match';
 
 export const WAIT_TIME_BEFORE_RECALC_WARNINGS = 500;
-
+const MAIL_BODY_DIV_ATTR = 'contenteditable';
 class JustNotSorry extends Component {
   constructor(props) {
     super(props);
@@ -39,7 +39,7 @@ class JustNotSorry extends Component {
           .filter(
             (mutation) =>
               mutation.type === 'childList' &&
-              mutation.target.hasAttribute('contentEditable')
+              mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
           )
           .forEach((mutation) => this.applyEventListeners(mutation.target));
       }
@@ -52,7 +52,7 @@ class JustNotSorry extends Component {
         .filter(
           (mutation) =>
             mutation.type !== 'characterData' &&
-            mutation.target.hasAttribute('contentEditable')
+            mutation.target.hasAttribute(MAIL_BODY_DIV_ATTR)
         )
         .forEach((mutation) => {
           // generate input event to fire checkForWarnings again


### PR DESCRIPTION
Easiest fix was to remove the editableDivCount as suggested.

Although initially introduced to anticipate any performance issues since outlook doesn't maintain a list of divs for each mail being written if performance does become an issue a different metric will have to be used to determine when to evaluate the contents of the message body.