### PR TITLE
Fix highlighting issue edge cases

### DIFF
--- a/src/warnings/phrases.json
+++ b/src/warnings/phrases.json
@@ -138,13 +138,13 @@
     ],
     "pattern": "(I'm just being honest here|If I'm being honest|Honestly|to be honest|if I'm honest|to be perfectly honest|in all honesty)",
     "source": "https://lifehacker.com/the-verbal-tee-ups-that-often-reveal-dishonesty-1505870461",
-    "message": "Tee-ups like this may make the reader shut down and respond negatively to your comment."
+    "message": "Tee-ups like this may make the reader shut down and respond negatively to your comment. --Thorin Klosowski"
   },
   {
     "displayLabel": ["I guess"],
     "pattern": "(I guess)",
     "source": "https://www.inc.com/mary-rezek/cut-kinda-sorta-i-guess-how-to-end-your-filler-word-bad-habits.html",
-    "message": "If you're sure of something, \"guessing\" detracts from your message and opens doubt in the reader's mind."
+    "message": "If you're sure of something, \"guessing\" detracts from your message and opens doubt in the reader's mind. --Mary Rezek"
   },
   {
     "displayLabel": ["Maybe"],

--- a/src/warnings/phrases.json
+++ b/src/warnings/phrases.json
@@ -94,10 +94,10 @@
     "message": "If you write an opinion, the reader understands that you also believe it is right. --David Bowman"
   },
   {
-    "displayLabel": ["I believe"],
-    "pattern": "(I believe)",
+    "displayLabel": ["I believe", "we believe"],
+    "pattern": "(I believe|we believe)",
     "source": "https://hbr.org/2011/12/replace-meaningless-words-with",
-    "message": "Phrases containing \"we believe,\" \"we think,\" and \"we feel\" pervade presentation narratives to such a degree that they spill over into sentences where caution is unnecessary. --Jerry Weissman"
+    "message": "Phrases containing \"we believe,\" \"we think,\" and \"we feel\" pervade presentation narratives to such a degree that they spill over into sentences where caution is unnecessary...the spillage weakens what should otherwise be assertive language. --Jerry Weissman"
   },
   {
     "displayLabel": ["I'm just saying"],

--- a/src/warnings/phrases.json
+++ b/src/warnings/phrases.json
@@ -94,8 +94,8 @@
     "message": "If you write an opinion, the reader understands that you also believe it is right. --David Bowman"
   },
   {
-    "displayLabel": ["I believe", "we believe"],
-    "pattern": "(I believe|we believe)",
+    "displayLabel": ["I believe", "We believe", "We feel"],
+    "pattern": "(I believe|we believe|we feel)",
     "source": "https://hbr.org/2011/12/replace-meaningless-words-with",
     "message": "Phrases containing \"we believe,\" \"we think,\" and \"we feel\" pervade presentation narratives to such a degree that they spill over into sentences where caution is unnecessary...the spillage weakens what should otherwise be assertive language. --Jerry Weissman"
   },

--- a/src/warnings/phrases.json
+++ b/src/warnings/phrases.json
@@ -7,25 +7,25 @@
   },
   {
     "displayLabel": ["Actually"],
-    "pattern": "\\b(actually)\\b",
+    "pattern": "(actually)",
     "source": "http://www.taramohr.com/8-ways-women-undermine-themselves-with-their-words/",
     "message": "\"Actually\" communicates a sense of surprise that you have something to say. Of course you want to add something. Of course you have questions. There's nothing surprising about it.  --Tara Sophia Mohr"
   },
   {
     "displayLabel": ["Sorry"],
-    "pattern": "\\b(sorry)\\b",
+    "pattern": "(sorry)",
     "source": "http://www.fastcompany.com/3032112/strong-female-lead/sorry-not-sorry-why-women-need-to-stop-apologizing-for-everything",
     "message": "Using \"sorry\" frequently undermines your gravitas and makes you appear unfit for leadership. --Sylvia Ann Hewlett"
   },
   {
     "displayLabel": ["Apologize", "Apologies", "Forgive"],
-    "pattern": "\\b(apologize|apologies|forgive)\\b",
+    "pattern": "(apologize|apologies|forgive)",
     "source": "http://www.fastcompany.com/3032112/strong-female-lead/sorry-not-sorry-why-women-need-to-stop-apologizing-for-everything",
     "message": "Apologizing unnecessarily puts you in a subservient position and makes people lose respect for you --Bonnie Marcus"
   },
   {
     "displayLabel": ["I think", "We think"],
-    "pattern": "\\b(I think|We think)\\b",
+    "pattern": "(I think|We think)",
     "source": "http://www.fastcompany.com/3049609/the-future-of-work/4-types-of-useless-phrases-you-need-to-eliminate-from-your-emails",
     "message": "\"I think\" undermines your idea and displays an overall lack of self-confidence. --Lydia Dishman"
   },
@@ -36,31 +36,31 @@
       "We're no experts",
       "We're not experts"
     ],
-    "pattern": "\\b(I'm no expert|We're no expert|We're no experts|We're not experts)\\b",
+    "pattern": "(I'm no expert|We're no expert|We're no experts|We're not experts)",
     "source": "http://www.fastcompany.com/3049609/the-future-of-work/4-types-of-useless-phrases-you-need-to-eliminate-from-your-emails",
     "message": "\"I'm no expert\" undermines your idea and displays an overall lack of self-confidence. --Lydia Dishman"
   },
   {
     "displayLabel": ["Yes, but"],
-    "pattern": "\\b(Yes, but)\\b",
+    "pattern": "(Yes, but)",
     "source": "http://www.strategicserendipityforlife.com/documents/Articles/Communication_8TipsForFearlessCommunicationInTheWorkplace.pdf",
     "message": "The \"Yes, but\" syndrome is entirely counterproductive, particularly in a work setting. You will become an integral part of any team if you are willing to build ideas rather than discard them. --Victoria Simon, Ph.D. and Holly Pedersen, Ph.D."
   },
   {
     "displayLabel": ["Literally"],
-    "pattern": "\\b(literally)\\b",
+    "pattern": "(literally)",
     "source": "https://expresswriters.com/50-weak-words-and-phrases-to-cut-out-of-your-blogging/",
     "message": "If something is literal, your readers should know it without you needing to use this word to clarify it. More often than not, the word \"literally\" makes writing sound flabby and juvenile, which is probably not what you're going for. --Julia McCoy"
   },
   {
     "displayLabel": ["Very"],
-    "pattern": "\\b(very)\\b",
+    "pattern": "(very)",
     "source": "http://blog.crew.co/5-weak-words-to-avoid/",
     "message": "The word 'very' does not communicate enough information. Find a stronger, more meaningful adverb, or omit it completely. --Andrea Ayres"
   },
   {
     "displayLabel": ["Kind of", "Sort of"],
-    "pattern": "\\b(kind of|sort of)\\b",
+    "pattern": "(kind of|sort of)",
     "source": "http://www.strategicserendipityforlife.com/documents/Articles/Communication_8TipsForFearlessCommunicationInTheWorkplace.pdf",
     "message": "This qualifier weakens the message as well as the authority of the writer. --Victoria Simon, Ph.D. and Holly Pedersen, Ph.D."
   },
@@ -71,43 +71,43 @@
       "Does this make sense",
       "Did this make sense"
     ],
-    "pattern": "\\b(does that make sense|did that make sense|does this make sense|did this make sense)\\b",
+    "pattern": "(does that make sense|did that make sense|does this make sense|did this make sense)",
     "source": "http://goop.com/how-women-undermine-themselves-with-words/",
     "message": "\"does that make sense\" comes across either as condescending (like your audience can't understand) or it implies you feel you've been incoherent. A better way to close is something like \"I look forward to hearing your thoughts.\" You can leave it up to the other party to let you know if they are confused about something, rather than implying that you \"didn't make sense.\" --Tara Sophia Mohr"
   },
   {
     "displayLabel": ["Try", "Trying", "Tried"],
-    "pattern": "\\b(try|trying|tried)\\b",
+    "pattern": "(trying|tried|try)",
     "source": "http://www.lifehack.org/articles/communication/7-things-not-to-say-and-7-things-to-start-saying.html",
     "message": "\"Do or do not. There is no try.\" --Yoda"
   },
   {
     "displayLabel": ["I should"],
-    "pattern": "\\b(I should)\\b",
+    "pattern": "(I should)",
     "source": "http://www.lifehack.org/articles/communication/7-things-not-to-say-and-7-things-to-start-saying.html",
     "message": "The word \"should\" is inherently negative. \"Should\" implies a lose: lose situation and it's just not conducive to positive outcomes in life. It's a form of criticism, and it's best left out of your everyday language. Instead of beating yourself up for what you should have done, focus on what you have the power to change. -- Zoe B"
   },
   {
     "displayLabel": ["I feel"],
-    "pattern": "\\b(I feel)\\b",
+    "pattern": "(I feel)",
     "source": "http://www.freelancewriting.com/articles/ten-words-to-avoid-when-writing.php",
     "message": "If you write an opinion, the reader understands that you also believe it is right. --David Bowman"
   },
   {
     "displayLabel": ["I believe"],
-    "pattern": "\\b(I believe)\\b",
+    "pattern": "(I believe)",
     "source": "https://hbr.org/2011/12/replace-meaningless-words-with",
     "message": "Phrases containing \"we believe,\" \"we think,\" and \"we feel\" pervade presentation narratives to such a degree that they spill over into sentences where caution is unnecessary. --Jerry Weissman"
   },
   {
     "displayLabel": ["I'm just saying"],
-    "pattern": "\\b(I'm just saying)\\b",
+    "pattern": "(I'm just saying)",
     "source": "http://101books.net/2012/03/02/7-annoying-words-that-should-die-a-horrible-death/",
     "message": "I think what you're saying is that you said something. If you're using it to mitigate something that may be offensive or embarrassing, then don't say it. Say something else. Otherwise, say what you're saying without the \"just saying.\" We already know you're saying it... after all, you just said it! --Robert Bruce"
   },
   {
     "displayLabel": ["In my opinion"],
-    "pattern": "\\b(In my opinion)\\b",
+    "pattern": "(In my opinion)",
     "source": "https://preciseedit.wordpress.com/2009/06/19/in-my-opinion-i-think-that-i-believe-this-is-bad-writing/",
     "message": "Phrases such as \"in my opinion,\" \"I think that,\" and \"I believe\" create three problems for writers: 1. They delay the writer's message; 2. They demonstrate insecurity; and 3. They tell the reader what he already knows. Remove that phrase, or any similar phrase, and get to the point. --David Bowman"
   },
@@ -116,13 +116,13 @@
       "This might be a stupid question",
       "This might be a silly idea"
     ],
-    "pattern": "\\b(This might be a stupid question|This might be a silly idea)\\b",
+    "pattern": "(This might be a stupid question|This might be a silly idea)",
     "source": "http://www.vogue.com/13362056/things-working-women-should-never-email/",
     "message": "Like they said in school, there are no stupid questions. Well, sometimes there are--but ask, don't caveat. --Alexandra Macon"
   },
   {
     "displayLabel": ["I may be wrong", "I might be wrong", "I could be wrong"],
-    "pattern": "\\b(I may be wrong|I might be wrong|I could be wrong)\\b",
+    "pattern": "(I may be wrong|I might be wrong|I could be wrong)",
     "source": "http://www.vogue.com/13362056/things-working-women-should-never-email/",
     "message": "Don't lessen the impact of what you say before you say it. --Alexandra Macon"
   },
@@ -136,19 +136,19 @@
       "to be perfectly honest",
       "in all honesty"
     ],
-    "pattern": "\\b(I'm just being honest here|If I'm being honest|Honestly|to be honest|if I'm honest|to be perfectly honest|in all honesty)\\b",
+    "pattern": "(I'm just being honest here|If I'm being honest|Honestly|to be honest|if I'm honest|to be perfectly honest|in all honesty)",
     "source": "https://lifehacker.com/the-verbal-tee-ups-that-often-reveal-dishonesty-1505870461",
     "message": "Tee-ups like this may make the reader shut down and respond negatively to your comment."
   },
   {
     "displayLabel": ["I guess"],
-    "pattern": "\\b(I guess)\\b",
+    "pattern": "(I guess)",
     "source": "https://www.inc.com/mary-rezek/cut-kinda-sorta-i-guess-how-to-end-your-filler-word-bad-habits.html",
     "message": "If you're sure of something, \"guessing\" detracts from your message and opens doubt in the reader's mind."
   },
   {
     "displayLabel": ["Maybe"],
-    "pattern": "\\b(Maybe)\\b",
+    "pattern": "(Maybe)",
     "source": "https://www.monster.com/career-advice/article/7-words-that-make-you-sound-less-confident-in-emails-0916",
     "message": "By adding \"maybe\" to your sentence, it makes it seem like you aren't confident in your answer/suggestion. Say what you mean. If you mean no, say no, if you mean yes, say yes."
   },


### PR DESCRIPTION
As reported in issue #117, the highlighting was not appearing in certain situations.  For example, if a warning phrase was on a line by itself.  This issue is due to the way the match utility finds the matches.

For example, when the email DOM text looks like this:

```html
<div>
  sorry checking
  <div>
    sorry
  </div>
</div>
```

Both instances "sorry" should be highlighted, but only the first one was being highlighted.  I tracked it down to this [line in util.js](https://github.com/defmethodinc/just-not-sorry/blob/beta/src/helpers/util.js#L27).  When we call `el.textContent`, the resulting string is "sorry checkingsorry" and the regular expression match for sorry, `\b(sorry)\b` doesn't pick up the second one.

I tried several approaches to fixing this issue, but none of them worked.  

In the end, I realized that a simple fix would be to loosen the regular expressions so that word boundaries aren't required.  This seems to work well.  The one case where I kept a word boundary in place was for "just", since I didn't want "justified" to be partially highlighted.

I also added "we believe" and "we feel" to the warning list, per Tami's request.

Fixes #117
