### PR TITLE
Highlighting issues #117 investigation

### DIFF
--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -21,6 +21,15 @@ const buildWarning = (pattern, message) => ({
   message,
 });
 
+const generateEditableDiv = (props, innerHtml) => {
+  const divNode = mount(
+    <div {...props} contentEditable={'true'}>
+      {innerHtml ? innerHtml : ''}
+    </div>
+  );
+  return divNode;
+};
+
 describe('JustNotSorry', () => {
   jest.useFakeTimers();
   let wrapper, instance, mutationObserverMock;
@@ -42,15 +51,6 @@ describe('JustNotSorry', () => {
   afterEach(() => {
     wrapper.unmount();
   });
-
-  const generateEditableDiv = (props, innerHtml) => {
-    const divNode = mount(
-      <div {...props} contentEditable={'true'}>
-        {innerHtml ? innerHtml : ''}
-      </div>
-    );
-    return divNode;
-  };
 
   describe('documentObserver', () => {
     it('listens for structural changes to the content editable div in document body', () => {

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -193,7 +193,6 @@ describe('JustNotSorry', () => {
       node.simulate('focus');
       jest.runOnlyPendingTimers();
 
-      expect(wrapper.state('warnings').length).toEqual(0);
       expect(wrapper.state('warnings')).toEqual([]);
     });
   });

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -74,15 +74,13 @@ describe('JustNotSorry', () => {
   describe('#handleSearch', () => {
     let handleSearch;
 
-    const setupHandler = () => {
+    beforeEach(() => {
       handleSearch = jest.spyOn(instance, 'handleSearch');
-    };
+    });
 
     const assertHandlerWasCalled = () => {
       expect(handleSearch).toHaveBeenCalledTimes(1);
     };
-
-    beforeEach(setupHandler);
 
     afterEach(assertHandlerWasCalled);
 

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -13,7 +13,8 @@ document.createRange = jest.fn(() => ({
     nodeName: 'BODY',
     ownerDocument: document,
   },
-  startContainer: 'test',
+  startContainer:
+    "The word 'very' does not communicate enough information. Find a stronger, more meaningful adverb, or omit it completely. --Andrea Ayres",
   getClientRects: jest.fn(() => [{}]),
 }));
 
@@ -172,18 +173,6 @@ describe('JustNotSorry', () => {
     });
 
     it('does not add warnings for tooltip matches', () => {
-      document.createRange = jest.fn(() => ({
-        setStart: jest.fn(),
-        setEnd: jest.fn(),
-        commonAncestorContainer: {
-          nodeName: 'BODY',
-          ownerDocument: document,
-        },
-        startContainer:
-          "The word 'very' does not communicate enough information. Find a stronger, more meaningful adverb, or omit it completely. --Andrea Ayres",
-        getClientRects: jest.fn(() => [{}]),
-      }));
-
       const node = enterText('test justify test');
       const domNode = node.getDOMNode();
       const mockedMutation = { type: 'childList', target: domNode };

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -65,18 +65,18 @@ describe('JustNotSorry', () => {
 
   describe('#handleSearch', () => {
     let handleSearch;
+
+    const setupHandler = () => {
+      handleSearch = jest.spyOn(instance, 'handleSearch');
+    };
+
+    const assertHandlerWasCalled = () => {
+      expect(handleSearch).toHaveBeenCalledTimes(1);
+    };
+
+    beforeEach(setupHandler);
+    afterEach(assertHandlerWasCalled);
     describe('on focus', () => {
-      const setupHandler = () => {
-        handleSearch = jest.spyOn(instance, 'handleSearch');
-      };
-
-      const assertHandlerWasCalled = () => {
-        expect(handleSearch).toHaveBeenCalledTimes(1);
-      };
-
-      beforeEach(setupHandler);
-      afterEach(assertHandlerWasCalled);
-
       it('checks for warnings', () => {
         const node = enterText('just not sorry');
 
@@ -108,7 +108,6 @@ describe('JustNotSorry', () => {
 
     describe('on input', () => {
       it('updates warnings each time input is triggered', () => {
-        const handleSearch = jest.spyOn(instance, 'handleSearch');
         const node = enterText('just not sorry');
 
         const domNode = node.getDOMNode();
@@ -118,13 +117,11 @@ describe('JustNotSorry', () => {
 
         node.simulate('input');
         jest.runOnlyPendingTimers();
-        expect(handleSearch).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('on cut', () => {
       it('updates warnings each time input is triggered', () => {
-        const handleSearch = jest.spyOn(instance, 'handleSearch');
         const node = enterText('just not sorry');
 
         const domNode = node.getDOMNode();
@@ -134,7 +131,6 @@ describe('JustNotSorry', () => {
 
         node.simulate('cut');
         jest.runOnlyPendingTimers();
-        expect(handleSearch).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -40,6 +40,7 @@ describe('JustNotSorry', () => {
     const documentObserver = mutationObserverMock.mock.instances[0];
     documentObserver.trigger([mockedMutation]);
     node.simulate(event);
+    jest.runOnlyPendingTimers();
   };
 
   beforeEach(() => {
@@ -83,14 +84,14 @@ describe('JustNotSorry', () => {
     };
 
     beforeEach(setupHandler);
+
     afterEach(assertHandlerWasCalled);
+
     describe('on focus', () => {
       it('checks for warnings', () => {
         const node = enterText('just not sorry');
 
         simulateEvent(node, 'focus');
-
-        jest.runOnlyPendingTimers();
 
         expect(wrapper.state('warnings').length).toEqual(2);
       });
@@ -99,8 +100,6 @@ describe('JustNotSorry', () => {
         const node = enterText();
 
         simulateEvent(node, 'focus');
-
-        jest.runOnlyPendingTimers();
 
         expect(wrapper.state('warnings').length).toEqual(0);
       });
@@ -111,8 +110,6 @@ describe('JustNotSorry', () => {
         const node = enterText('just not sorry');
 
         simulateEvent(node, 'input');
-
-        jest.runOnlyPendingTimers();
       });
     });
 
@@ -121,8 +118,6 @@ describe('JustNotSorry', () => {
         const node = enterText('just not sorry');
 
         simulateEvent(node, 'cut');
-
-        jest.runOnlyPendingTimers();
       });
     });
   });
@@ -157,11 +152,7 @@ describe('JustNotSorry', () => {
 
     it('does not add warnings for tooltip matches', () => {
       const node = enterText('test justify test');
-
       simulateEvent(node, 'focus');
-
-      jest.runOnlyPendingTimers();
-
       expect(wrapper.state('warnings').length).toBe(0);
     });
   });

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -193,7 +193,7 @@ describe('JustNotSorry', () => {
       node.simulate('focus');
       jest.runOnlyPendingTimers();
 
-      expect(wrapper.state('warnings')).toEqual([]);
+      expect(wrapper.state('warnings').length).toBe(0);
     });
   });
 });

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -36,9 +36,8 @@ describe('JustNotSorry', () => {
 
   const simulateEvent = (node, event) => {
     const domNode = node.getDOMNode();
-    const mockedMutation = { type: 'childList', target: domNode };
     const documentObserver = mutationObserverMock.mock.instances[0];
-    documentObserver.trigger([mockedMutation]);
+    documentObserver.trigger([{ type: 'childList', target: domNode }]);
     node.simulate(event);
     jest.runOnlyPendingTimers();
   };

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -26,7 +26,7 @@ const buildWarning = (pattern, message) => ({
 const enterText = (text) => {
   return mount(
     <div props={{ id: 'div-focus' }} contentEditable={'true'}>
-      {text ? text : ''}
+      {text ?? ''}
     </div>
   );
 };

--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -34,6 +34,14 @@ const enterText = (text) => {
 describe('JustNotSorry', () => {
   let wrapper, instance, mutationObserverMock;
 
+  const simulateEvent = (node, event) => {
+    const domNode = node.getDOMNode();
+    const mockedMutation = { type: 'childList', target: domNode };
+    const documentObserver = mutationObserverMock.mock.instances[0];
+    documentObserver.trigger([mockedMutation]);
+    node.simulate(event);
+  };
+
   beforeEach(() => {
     mutationObserverMock = jest.fn(function MutationObserver(callback) {
       this.observe = jest.fn();
@@ -80,12 +88,8 @@ describe('JustNotSorry', () => {
       it('checks for warnings', () => {
         const node = enterText('just not sorry');
 
-        const domNode = node.getDOMNode();
-        const mockedMutation = { type: 'childList', target: domNode };
-        const documentObserver = mutationObserverMock.mock.instances[0];
-        documentObserver.trigger([mockedMutation]);
+        simulateEvent(node, 'focus');
 
-        node.simulate('focus');
         jest.runOnlyPendingTimers();
 
         expect(wrapper.state('warnings').length).toEqual(2);
@@ -94,12 +98,8 @@ describe('JustNotSorry', () => {
       it('does nothing when given an empty string', () => {
         const node = enterText();
 
-        const domNode = node.getDOMNode();
-        const mockedMutation = { type: 'childList', target: domNode };
-        const documentObserver = mutationObserverMock.mock.instances[0];
-        documentObserver.trigger([mockedMutation]);
+        simulateEvent(node, 'focus');
 
-        node.simulate('focus');
         jest.runOnlyPendingTimers();
 
         expect(wrapper.state('warnings').length).toEqual(0);
@@ -110,12 +110,8 @@ describe('JustNotSorry', () => {
       it('updates warnings each time input is triggered', () => {
         const node = enterText('just not sorry');
 
-        const domNode = node.getDOMNode();
-        const mockedMutation = { type: 'childList', target: domNode };
-        const documentObserver = mutationObserverMock.mock.instances[0];
-        documentObserver.trigger([mockedMutation]);
+        simulateEvent(node, 'input');
 
-        node.simulate('input');
         jest.runOnlyPendingTimers();
       });
     });
@@ -124,12 +120,8 @@ describe('JustNotSorry', () => {
       it('updates warnings each time input is triggered', () => {
         const node = enterText('just not sorry');
 
-        const domNode = node.getDOMNode();
-        const mockedMutation = { type: 'childList', target: domNode };
-        const documentObserver = mutationObserverMock.mock.instances[0];
-        documentObserver.trigger([mockedMutation]);
+        simulateEvent(node, 'cut');
 
-        node.simulate('cut');
         jest.runOnlyPendingTimers();
       });
     });
@@ -142,12 +134,7 @@ describe('JustNotSorry', () => {
 
         const node = enterText('just not sorry');
 
-        const domNode = node.getDOMNode();
-        const mockedMutation = { type: 'childList', target: domNode };
-        const documentObserver = mutationObserverMock.mock.instances[0];
-        documentObserver.trigger([mockedMutation]);
-
-        node.simulate('blur');
+        simulateEvent(node, 'blur');
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(wrapper.state('warnings').length).toEqual(0);
@@ -170,12 +157,9 @@ describe('JustNotSorry', () => {
 
     it('does not add warnings for tooltip matches', () => {
       const node = enterText('test justify test');
-      const domNode = node.getDOMNode();
-      const mockedMutation = { type: 'childList', target: domNode };
-      const documentObserver = mutationObserverMock.mock.instances[0];
-      documentObserver.trigger([mockedMutation]);
 
-      node.simulate('focus');
+      simulateEvent(node, 'focus');
+
       jest.runOnlyPendingTimers();
 
       expect(wrapper.state('warnings').length).toBe(0);

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -41,14 +41,24 @@ class JustNotSorry extends Component {
     this.setState({ parentNode: {}, warnings: [] });
   }
 
-  updateWarnings(elem, patterns) {
-    const newWarnings = findRanges(elem, patterns);
-    this.setState({ parentNode: elem.parentNode, warnings: newWarnings });
+  updateWarnings(email, patterns) {
+    const newWarnings =
+      email.children.size > 0
+        ? Array.from(email.children)
+            .filter((node) => node.text !== '')
+            .flatMap((node) => findRanges(node, patterns))
+        : findRanges(email, patterns);
+    this.setState(({ parentNode }) =>
+      parentNode.id !== email.parentNode.id
+        ? { parentNode: email.parentNode, warnings: newWarnings }
+        : { parentNode, warning: newWarnings }
+    );
+    this.setState({ parentNode: email.parentNode, warnings: newWarnings });
   }
 
-  handleSearch(elem, patterns) {
+  handleSearch(email, patterns) {
     return Util.debounce(
-      () => this.updateWarnings(elem, patterns),
+      () => this.updateWarnings(email, patterns),
       WAIT_TIME_BEFORE_RECALC_WARNINGS
     );
   }

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -43,7 +43,7 @@ class JustNotSorry extends Component {
 
   updateWarnings(email, patterns) {
     const newWarnings =
-      email.children.size > 0
+      email.children.length > 0
         ? Array.from(email.children)
             .filter((node) => node.text !== '')
             .flatMap((node) => findRanges(node, patterns))

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -51,7 +51,7 @@ class JustNotSorry extends Component {
     this.setState(({ parentNode }) =>
       parentNode.id !== email.parentNode.id
         ? { parentNode: email.parentNode, warnings: newWarnings }
-        : { parentNode, warning: newWarnings }
+        : { parentNode, warnings: newWarnings }
     );
     this.setState({ parentNode: email.parentNode, warnings: newWarnings });
   }

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -45,15 +45,15 @@ class JustNotSorry extends Component {
     const newWarnings =
       email.children.length > 0
         ? Array.from(email.children)
-            .filter((node) => node.text !== '')
-            .flatMap((node) => findRanges(node, patterns))
+            .filter((node) => node.textContent !== '')
+            .flatMap((text) => findRanges(text, patterns))
         : findRanges(email, patterns);
+
     this.setState(({ parentNode }) =>
       parentNode.id !== email.parentNode.id
         ? { parentNode: email.parentNode, warnings: newWarnings }
         : { parentNode, warnings: newWarnings }
     );
-    this.setState({ parentNode: email.parentNode, warnings: newWarnings });
   }
 
   handleSearch(email, patterns) {

--- a/src/helpers/RangeFinder.js
+++ b/src/helpers/RangeFinder.js
@@ -8,10 +8,5 @@ function search(email, phrase) {
 }
 
 export function findRanges(element, patternsToFind) {
-  const newWarnings = [];
-  for (let i = 0; i < patternsToFind.length; i++) {
-    const warnings = search(element, patternsToFind[i]);
-    newWarnings.push(...warnings);
-  }
-  return newWarnings;
+  return patternsToFind.flatMap((pattern) => search(element, pattern));
 }

--- a/src/helpers/RangeFinder.js
+++ b/src/helpers/RangeFinder.js
@@ -1,12 +1,12 @@
 import * as Util from './util';
 
-function search(email, phrase) {
-  return Util.match(email, phrase.regex).map((range) => ({
+function search(element, phrase) {
+  return Util.match(element, phrase.regex).map((range) => ({
     message: phrase.message,
     rangeToHighlight: range,
   }));
 }
 
-export function findRanges(element, patternsToFind) {
-  return patternsToFind.flatMap((pattern) => search(element, pattern));
+export function findRanges(node, patternsToFind) {
+  return patternsToFind.flatMap((pattern) => search(node, pattern));
 }


### PR DESCRIPTION
I verified things are still working on outlook and gmail.

I don't think performance has taken a hit either. I've tried to compare before and after the fix in place and haven't noticed much differences I was using issue #110  as an example.

For the fix I added a check to see if the target html element contains any child nodes and to check those for pattern matches, else just check the node itself.

The reason I added this is when investigating the DOM of an email the text was wrapped in their own self contained divs. When we look for a pattern match textContent appears to return a "textified" version of this by converting them to 
\n and returning the entire contents as one string which then fails the entire parser.