### PR TITLE
fix: fix issue with warnings not appearing for first line of email text

### DIFF
--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -147,6 +147,25 @@ describe('JustNotSorry', () => {
       expect(wrapper.state('parentNode')).toBe(domNode.parentNode);
     });
 
+    describe('when there are top-level and child nodes', () => {
+      it('catches the warnings for both', () => {
+        const elem = mount(
+          <div props={{ id: 'div-focus' }} contentEditable={'true'}>
+            test!!!
+            <div>Hello!!!</div>
+          </div>
+        );
+
+        const domNode = elem.getDOMNode();
+        instance.updateWarnings(domNode, [
+          buildWarning('\\b!{3,}\\B', 'warning message'),
+        ]);
+
+        expect(wrapper.state('warnings').length).toBe(2);
+        expect(wrapper.state('parentNode')).toBe(domNode.parentNode);
+      });
+    });
+
     it('does not add warnings for tooltip matches', () => {
       const node = enterText('test justify test');
       simulateEvent(node, 'focus');

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -43,8 +43,8 @@ class JustNotSorry extends Component {
 
   updateWarnings(email, patterns) {
     const newWarnings =
-      email.children.length > 0
-        ? Array.from(email.children)
+      email.childNodes.length > 0
+        ? Array.from(email.childNodes)
             .filter((node) => node.textContent !== '')
             .flatMap((text) => findRanges(text, patterns))
         : findRanges(email, patterns);


### PR DESCRIPTION
I noticed that the warnings weren't appearing for the first paragraph of email text.  It turns out that we needed to use `childNodes` instead of `children` in order to pick up both the child elements with text and the DOM text nodes directly associated with the element.

re #117
