### PR TITLE
Provide feedback about changes when extension is updated

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -1,6 +1,6 @@
 var gaService = analytics.getService('JustNotSorryTest');
 
-chrome.runtime.onInstalled.addListener(function () {
+chrome.runtime.onInstalled.addListener(async function ({ reason }) {
   var tracker = gaService.getTracker('UA-3535278-4'); // prod
   var timing = tracker.startTiming('Analytics Performance', 'Send Event');
   tracker.sendAppView('JustNotSorryInstalled');
@@ -24,6 +24,11 @@ chrome.runtime.onInstalled.addListener(function () {
       },
     ]);
   });
+
+  if (reason === 'update') {
+    const url = 'https://defmethodinc.github.io/just-not-sorry/upgraded';
+    await chrome.tabs.create({ url });
+  }
 });
 
 chrome.pageAction.onClicked.addListener(function () {

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,7 @@
   "permissions": [
     "https://www.google-analytics.com/",
     "storage",
+    "tabs",
     "declarativeContent"
   ]
 }


### PR DESCRIPTION
When the extension for an existing user is updated, the change in this PR will open a new tab alerting them of the update and showing a simplified change log at https://defmethodinc.github.io/just-not-sorry/upgraded

I would have liked to use our automatically generated change logs but they're too technical and detailed for a general audience.