### PR TITLE
fix: add support for outlook web for business

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -14,7 +14,7 @@ chrome.runtime.onInstalled.addListener(async function ({ reason }) {
             pageUrl: { urlContains: 'mail.google.com' },
           }),
           new chrome.declarativeContent.PageStateMatcher({
-            pageUrl: { urlContains: 'inbox.google.com' },
+            pageUrl: { urlContains: 'outlook.office.com' },
           }),
           new chrome.declarativeContent.PageStateMatcher({
             pageUrl: { urlContains: 'outlook.live.com' },

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     {
       "matches": [
         "https://mail.google.com/*",
-        "https://inbox.google.com/*",
+        "https://outlook.office.com/*",
         "https://outlook.live.com/*"
       ],
       "css": ["./just-not-sorry.css"],


### PR DESCRIPTION
It uses outlook.office.com rather than the outlook.live.com used for personal accounts.