### PR TITLE
fix: fix error when previewing attachment on outlook.office.com

### DIFF
--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -147,6 +147,32 @@ describe('JustNotSorry', () => {
       expect(wrapper.state('parentNode')).toBe(domNode.parentNode);
     });
 
+    describe('when the email node is null', () => {
+      it('clears the state', () => {
+        instance.updateWarnings(null, [
+          buildWarning('\\b!{3,}\\B', 'warning message'),
+        ]);
+
+        expect(wrapper.state('warnings').length).toEqual(0);
+        expect(wrapper.state('parentNode')).toEqual({});
+      });
+    });
+
+    describe('when the email node has an offsetParent of null', () => {
+      it('clears the state', () => {
+        const emailNode = {
+          offsetParent: null,
+          childNodes: [],
+        };
+        instance.updateWarnings(emailNode, [
+          buildWarning('\\b!{3,}\\B', 'warning message'),
+        ]);
+
+        expect(wrapper.state('warnings').length).toEqual(0);
+        expect(wrapper.state('parentNode')).toEqual({});
+      });
+    });
+
     describe('when there are top-level and child nodes', () => {
       it('catches the warnings for both', () => {
         const elem = mount(

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -42,6 +42,10 @@ class JustNotSorry extends Component {
   }
 
   updateWarnings(email, patterns) {
+    if (!email || !email.offsetParent) {
+      this.resetState();
+      return;
+    }
     const newWarnings =
       email.childNodes.length > 0
         ? Array.from(email.childNodes)


### PR DESCRIPTION
this fix guards against edge cases where the contentEditable being monitored does not have an
offsetParent, which can happen if the node has position of 'fixed'.

Closes #141