### PR TITLE
chore: use main instead of master for primary branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["master", { "name": "beta", "prerelease": "beta" }],
+  "branches": ["main", { "name": "beta", "prerelease": "beta" }],
   "plugins": [
     "@semantic-release/commit-analyzer",
     [

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run test:watch
 
 ### To Publish a New Version to Chrome Webstore
 
-This project uses the [semantic-release](https://semantic-release.gitbook.io/semantic-release/) library and [GitHub Actions](https://help.github.com/en/actions) to automate the release process. Once a pull request has been merged into the master branch, a new [GitHub release](https://github.com/defmethodinc/just-not-sorry/releases) will be created. A zip file containing the updated files for the Chrome web store will be attached.
+This project uses the [semantic-release](https://semantic-release.gitbook.io/semantic-release/) library and [GitHub Actions](https://help.github.com/en/actions) to automate the release process. Once a pull request has been merged into the main branch, a new [GitHub release](https://github.com/defmethodinc/just-not-sorry/releases) will be created. A zip file containing the updated files for the Chrome web store will be attached.
 
 To publish this release, download the zip file from GitHub. Find the Just Not Sorry extension on the [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole/) (credentials available to DefMethod developers upon request), upload the zip file, and click the "Publish Item" button.
 

--- a/options/options.ejs
+++ b/options/options.ejs
@@ -70,7 +70,7 @@
   <p><em>
     We never collect anything personally identifiable and don't collect
     anything about the email that you're writing.  See our
-    <a href="https://github.com/defmethodinc/just-not-sorry/blob/master/PRIVACY.md">privacy policy</a>
+    <a href="https://github.com/defmethodinc/just-not-sorry/blob/main/PRIVACY.md">privacy policy</a>
     for more information.
   </em></p>
 


### PR DESCRIPTION
because `main` is more inclusive and does not have the same negative associations as `master`