### PR TITLE
Fix React test warnings

### DIFF
--- a/spec/JustNotSorrySpec.test.js
+++ b/spec/JustNotSorrySpec.test.js
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { act } from 'react';
 import JustNotSorry from '../src/components/JustNotSorry.js';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
 
 jest.useFakeTimers();
 

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -5,7 +5,10 @@ import * as Util from '../helpers/util.js';
 import { forEachUniqueContentEditable } from '../callbacks/ContentEditableDiv';
 import { calculateWarnings } from '../helpers/RangeFinder';
 
-const JustNotSorry = ({ onEvents, phrases }) => {
+const JustNotSorry = ({
+  onEvents = ['input', 'focus', 'cut'],
+  phrases = [],
+}) => {
   const email = useRef(null);
   const [observer, setObserver] = useState(null);
   const [warnings, setWarnings] = useState([]);
@@ -75,8 +78,4 @@ const JustNotSorry = ({ onEvents, phrases }) => {
   }
 };
 
-JustNotSorry.defaultProps = {
-  onEvents: ['input', 'focus', 'cut'],
-  phrases: [],
-};
 export default JustNotSorry;


### PR DESCRIPTION
## What changed

- Replace function-component `defaultProps` with JavaScript default parameters.
- Import `act` from React instead of the deprecated `react-dom/test-utils` API.

## Why

The Babel, Webpack, and Jest upgrade exposed two React deprecation warnings during the unit suite. These changes use the supported React APIs while preserving the component's existing default values and test behavior.

## Impact

The unit suite now runs without the React deprecation warnings. Extension behavior is unchanged.

## Validation

- `npm test -- --runInBand` — 253 tests passed
- `npm run build` — Webpack compiled successfully
- Pre-commit and pre-push hooks passed
