### PR TITLE
Upgrade React and react-tooltip

### DIFF
--- a/docs/superpowers/plans/2026-07-22-react-19-tooltip-6.md
+++ b/docs/superpowers/plans/2026-07-22-react-19-tooltip-6.md
@@ -1,0 +1,242 @@
+# React 19 and React Tooltip 6 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the extension UI dependencies to React 19.2.7 and
+react-tooltip 6.0.8 while preserving all warning and extension behavior.
+
+**Architecture:** Keep the existing React component and warning pipeline
+intact. Characterize the tooltip/highlight contract, update only dependency and
+React API boundaries, and verify both source behavior and generated browser
+extension output.
+
+**Tech Stack:** React 19, React DOM 19, react-tooltip 6, Jest, Testing Library,
+Webpack, Puppeteer, web-ext
+
+## Global Constraints
+
+- Use exactly `react` 19.2.7, `react-dom` 19.2.7, `react-tooltip` 6.0.8, and
+  `prop-types` 15.8.1.
+- Preserve warning detection, highlight placement, tooltip content, options
+  rendering, and content-editable interactions.
+- Introduce no intentional public extension API or manifest behavior changes.
+- Make no unrelated source or dependency changes.
+
+---
+
+### Task 1: Characterize the Tooltip Contract
+
+**Files:**
+
+- Modify: `spec/WarningHighlightSpec.test.js`
+- Test: `spec/WarningHighlightSpec.test.js`
+
+**Interfaces:**
+
+- Consumes: `WarningHighlight({ number, message, container, bounds })`
+- Produces: regression assertions for `data-tooltip-id`,
+  `data-tooltip-content`, highlight geometry, and the tooltip component id
+
+- [ ] **Step 1: Strengthen the focused characterization test**
+
+Pass `number={3}` in the shared render and extend the attribute test with:
+
+```js
+expect(jnsHighlight.dataset.tooltipId).toEqual('jns-highlight-3');
+expect(jnsHighlight.dataset.tooltipContent).toEqual('test-message');
+expect(document.getElementById('jns-highlight-3')).toHaveClass('jns-tooltip');
+```
+
+If react-tooltip intentionally defers the tooltip node until interaction, use
+`userEvent.hover(jnsHighlight)` and `await screen.findByRole('tooltip')`, then
+assert that node has id `jns-highlight-3` and class `jns-tooltip`.
+
+- [ ] **Step 2: Run the characterization test before the upgrade**
+
+Run: `npm test -- --runInBand spec/WarningHighlightSpec.test.js`
+
+Expected: PASS, proving the assertions describe current user-visible behavior.
+
+- [ ] **Step 3: Commit the characterization test**
+
+```bash
+git add spec/WarningHighlightSpec.test.js
+git commit -m "test: preserve warning tooltip behavior"
+```
+
+### Task 2: Upgrade Dependencies and Adapt Supported APIs
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify only if the upgraded tests or build require it: `src/index.js`
+- Modify only if the upgraded tests or build require it:
+  `src/components/JustNotSorry.js`
+- Modify only if the upgraded tests or build require it:
+  `src/components/WarningHighlight.js`
+- Test: `spec/WarningHighlightSpec.test.js`
+- Test: `spec/JustNotSorrySpec.test.js`
+
+**Interfaces:**
+
+- Consumes: React client root/hydration exports, React DOM `createPortal`, and
+  react-tooltip's `Tooltip` plus `data-tooltip-*` anchor attributes
+- Produces: the same rendered `JustNotSorry` portal and warning highlight DOM
+  under the upgraded packages
+
+- [ ] **Step 1: Install the exact requested versions**
+
+Run:
+
+```bash
+npm install --save-dev --save-exact react@19.2.7 react-dom@19.2.7 react-tooltip@6.0.8
+npm install --save --save-exact prop-types@15.8.1
+```
+
+Expected: `package.json` and `package-lock.json` resolve the four exact versions
+and no unrelated top-level package changes appear.
+
+- [ ] **Step 2: Verify the upgrade exposes compatibility failures**
+
+Run:
+
+```bash
+npm test -- --runInBand spec/WarningHighlightSpec.test.js spec/JustNotSorrySpec.test.js
+```
+
+Expected: either a focused failure or compatibility warning identifying an
+obsolete import/prop, or clean passes showing the existing API is supported.
+Record the output so every subsequent source edit responds to observed behavior.
+
+- [ ] **Step 3: Make the minimal supported-API edits**
+
+Use named supported exports without changing component behavior:
+
+```js
+// src/index.js, if namespace hydration access warns or fails
+import { hydrateRoot } from 'react-dom/client';
+
+hydrateRoot(
+  document.body,
+  <JustNotSorry
+    phrases={MESSAGE_PATTERNS}
+    onEvents={['input', 'focus', 'cut']}
+  />,
+);
+```
+
+```js
+// src/components/JustNotSorry.js, if default interop warns or fails
+import { createPortal } from 'react-dom';
+
+return createPortal(warningComponents, currentEmail.offsetParent);
+```
+
+Keep `WarningHighlight` on the version-6 `Tooltip` export and its existing
+`id`, `float`, `className`, `data-tooltip-id`, and `data-tooltip-content`
+contract unless the focused failure demonstrates a renamed supported prop.
+There are currently no function-component `defaultProps` declarations; retain
+the existing parameter defaults in `JustNotSorry`.
+
+- [ ] **Step 4: Run focused tests and eliminate compatibility warnings**
+
+Run:
+
+```bash
+npm test -- --runInBand spec/WarningHighlightSpec.test.js spec/JustNotSorrySpec.test.js
+```
+
+Expected: PASS with no React act, legacy root, hydration, portal, unknown prop,
+or function-component `defaultProps` warnings.
+
+- [ ] **Step 5: Confirm dependency and source scope**
+
+Run:
+
+```bash
+npm ls react react-dom react-tooltip prop-types
+git diff -- package.json package-lock.json src spec
+```
+
+Expected: the requested exact versions are installed and the diff contains only
+the focused compatibility/test changes described above.
+
+- [ ] **Step 6: Commit the migration**
+
+```bash
+git add package.json package-lock.json src/index.js src/components/JustNotSorry.js src/components/WarningHighlight.js
+git commit -m "build: upgrade React and react-tooltip"
+```
+
+Stage only source files that actually changed.
+
+### Task 3: Verify Source and Generated Extension Output
+
+**Files:**
+
+- Verify: `src/**`
+- Verify generated ignored output: `build/**`
+
+**Interfaces:**
+
+- Consumes: upgraded application source and dependency graph
+- Produces: unit-tested, linted, formatted, bundled, extension-linted, and
+  browser-smoke-tested output
+
+- [ ] **Step 1: Run the full source quality suite**
+
+Run:
+
+```bash
+npm test -- --runInBand
+npm run lint:check
+npm run format:check
+```
+
+Expected: 7 test suites and 253 or more tests pass; ESLint and Prettier report
+no failures; test output contains no React compatibility warnings.
+
+- [ ] **Step 2: Build and lint the extension**
+
+Run:
+
+```bash
+npm run build
+npx web-ext lint -s ./build
+```
+
+Expected: Webpack completes without errors and web-ext reports no extension
+errors.
+
+- [ ] **Step 3: Run automated E2E coverage**
+
+Run: `npm run e2e`
+
+Expected: the Puppeteer E2E suite passes against the generated extension
+output.
+
+- [ ] **Step 4: Smoke-test supported local browsers**
+
+Run the repository's Chrome/Chromium workflow against `build/`, load a compose
+surface, type a known warning phrase such as `just`, and verify a highlight and
+its tooltip appear. Repeat with the Firefox workflow where Firefox is installed.
+Record any browser that cannot run because the executable or interactive Gmail
+session is unavailable; do not treat an unavailable browser as a successful
+smoke test.
+
+- [ ] **Step 5: Inspect the final branch**
+
+Run:
+
+```bash
+git status -sb
+git diff --check HEAD~2..HEAD
+git log --oneline --decorate -5
+```
+
+Expected: the worktree is clean, there are no whitespace errors, and the branch
+contains only the design, characterization, and dependency migration commits.

--- a/docs/superpowers/specs/2026-07-22-react-19-tooltip-6-design.md
+++ b/docs/superpowers/specs/2026-07-22-react-19-tooltip-6-design.md
@@ -1,0 +1,65 @@
+# React 19 and React Tooltip 6 Upgrade Design
+
+## Goal
+
+Upgrade the extension UI to React 19.2.7, React DOM 19.2.7,
+react-tooltip 6.0.8, and prop-types 15.8.1 without changing observable
+warning behavior or the extension's public and manifest interfaces.
+
+## Approach
+
+Use a minimal compatibility migration. Update the dependency manifest and lock
+file, then change application code only where React 19 or react-tooltip 6 no
+longer supports the existing API. Do not use this upgrade to restructure the
+warning pipeline, alter copy, or modernize unrelated code.
+
+Dependency-only installation is too optimistic because it would leave any
+removed APIs or compatibility warnings undiscovered. A broader React rewrite
+would expand regression risk without helping this issue. The selected approach
+keeps the migration narrow while explicitly exercising the affected UI.
+
+## Components and APIs
+
+- `src/index.js` remains responsible for mounting `JustNotSorry` into the
+  extension document. It will use the React 19-supported client root or
+  hydration API appropriate for the existing generated page.
+- `src/components/JustNotSorry.js` retains the warning calculation, event
+  listener, and content-editable behavior. Its portal call will use the
+  React 19-supported `react-dom` export without changing the portal target.
+- `src/components/WarningHighlight.js` retains highlight geometry, tooltip
+  content, and tooltip identity. Its react-tooltip integration will be adapted
+  only if version 6 requires an API change.
+- Function-component defaults will be expressed as parameter defaults wherever
+  the source still relies on `defaultProps`. Existing parameter defaults remain
+  unchanged.
+
+## Behavior Preservation
+
+The warning phrase data and matching pipeline are out of scope. A detected
+warning must still create a highlight at the same calculated bounds, expose the
+same message through its tooltip, and render into the current content-editable
+element's offset parent. Options rendering, extension manifest behavior, and
+public extension APIs must not intentionally change.
+
+## Testing and Verification
+
+Preserve the existing warning and content-editable unit assertions. Strengthen
+the focused highlight test if necessary so it verifies the tooltip identifier,
+content, and rendered tooltip integration rather than merely accepting a
+dependency upgrade. Tests that expose React 19 compatibility warnings will be
+treated as failures.
+
+After the focused test-first migration, run the complete unit suite, ESLint,
+Prettier check, production build, and E2E suite. Lint the generated extension
+with `web-ext`. Smoke-test the generated output with the repository's supported
+Chrome/Chromium and Firefox workflows where the local environment provides the
+required browsers; document any unavailable browser rather than weakening the
+automated checks.
+
+## Constraints
+
+- Pin `react` and `react-dom` to 19.2.7, `react-tooltip` to 6.0.8, and
+  `prop-types` to 15.8.1 as required by issue #195.
+- Introduce no intentional warning copy, warning placement, manifest, public
+  API, or content-editable interaction changes.
+- Avoid unrelated refactoring and dependency changes.

--- a/e2e/global-setup.js
+++ b/e2e/global-setup.js
@@ -2,6 +2,6 @@ import { e2eSetup } from './utility.js';
 import setupPuppeteer from 'jest-environment-puppeteer/setup';
 
 export default async function globalSetup(globalConfig) {
-  e2eSetup();
+  await e2eSetup();
   await setupPuppeteer(globalConfig);
 }

--- a/e2e/global-teardown.js
+++ b/e2e/global-teardown.js
@@ -3,5 +3,5 @@ import teardownPuppeteer from 'jest-environment-puppeteer/teardown';
 
 export default async function globalTeardown(globalConfig) {
   await teardownPuppeteer(globalConfig);
-  e2eTeardown();
+  await e2eTeardown();
 }

--- a/e2e/utility.js
+++ b/e2e/utility.js
@@ -1,33 +1,16 @@
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 import * as path from 'path';
 
 // eslint-disable-next-line no-undef
 const manifestPath = path.join(__dirname, '..', 'build', 'manifest.json');
-export function e2eSetup() {
-  fs.readFile(manifestPath, (err, data) => {
-    if (err) throw err;
-    const newValue = data
-      .toString()
-      .replace(
-        'https://mail.google.com/*',
-        'file:///*/just-not-sorry/public/jns-test.html'
-      );
-    fs.writeFile(manifestPath, newValue, 'utf-8', function (err) {
-      if (err) throw err;
-    });
-  });
+const testPageMatch = 'file:///*/public/jns-test.html';
+export async function e2eSetup() {
+  const data = await fs.readFile(manifestPath, 'utf-8');
+  const newValue = data.replace('https://mail.google.com/*', testPageMatch);
+  await fs.writeFile(manifestPath, newValue, 'utf-8');
 }
-export function e2eTeardown() {
-  fs.readFile(manifestPath, (err, data) => {
-    if (err) throw err;
-    const newValue = data
-      .toString()
-      .replace(
-        'file:///*/just-not-sorry/public/jns-test.html',
-        'https://mail.google.com/*'
-      );
-    fs.writeFile(manifestPath, newValue, 'utf-8', function (err) {
-      if (err) throw err;
-    });
-  });
+export async function e2eTeardown() {
+  const data = await fs.readFile(manifestPath, 'utf-8');
+  const newValue = data.replace(testPageMatch, 'https://mail.google.com/*');
+  await fs.writeFile(manifestPath, newValue, 'utf-8');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
-        "prop-types": "^15.7.2",
+        "prop-types": "15.8.1",
         "range-at-index": "^1.0.4"
       },
       "devDependencies": {
@@ -23,8 +23,9 @@
         "@eslint/js": "^9.39.5",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
+        "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
-        "@testing-library/react": "^14.3.1",
+        "@testing-library/react": "16.3.2",
         "babel-loader": "^10.1.1",
         "commitizen": "^4.3.2",
         "concurrently": "^10.0.3",
@@ -47,9 +48,9 @@
         "lint-staged": "^17.1.0",
         "prettier": "^3.9.6",
         "puppeteer-core": "^25.3.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-tooltip": "^5.30.1",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
+        "react-tooltip": "6.0.8",
         "semantic-release": "^24.2.9",
         "style-loader": "^4.0.0",
         "web-ext": "^8.10.0",
@@ -5316,14 +5317,14 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -7508,7 +7509,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7528,7 +7528,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7541,7 +7540,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7555,8 +7553,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "7.0.0",
@@ -7589,88 +7586,32 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
-        "@types/react-dom": "^18.0.0"
+        "@babel/runtime": "^7.12.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
-      "engines": {
-        "node": ">=14"
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@testing-library/react/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
@@ -7945,12 +7886,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -7965,38 +7900,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
@@ -11029,12 +10938,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
-    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -11209,6 +11112,16 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -12105,12 +12018,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
-    },
     "node_modules/cwd": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -12279,46 +12186,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-equal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -13123,34 +12990,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.4.0",
@@ -15991,23 +15830,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -22184,23 +22006,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -23519,30 +23324,26 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -23551,14 +23352,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-tooltip": {
-      "version": "5.30.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
-      "integrity": "sha512-1lSPLQXuVooePxadUpmcwLgOsF1mIty7UZTJ9XnyfX4drOzStYs4JMXnazcDLguQr41W5OUZddOp9kfvArdpEQ==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.8.tgz",
+      "integrity": "sha512-VPjtBPyoFwq72QVE6GYB/LtfEg/mnFBHqL0nD0oNNmjH8EZYFyBwgnFKNCOp5zCte45k1weXjKc0wXE6NICpfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
+        "@floating-ui/dom": "1.7.6",
+        "clsx": "2.1.1"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -24186,14 +23987,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -31401,13 +31199,13 @@
       }
     },
     "@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "dev": true,
       "requires": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "@floating-ui/utils": {
@@ -32941,7 +32739,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -32957,15 +32754,13 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "pretty-format": {
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
           "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
@@ -32976,8 +32771,7 @@
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -33004,64 +32798,12 @@
       }
     },
     "@testing-library/react": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
-        "@types/react-dom": "^18.0.0"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "9.3.4",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-          "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^5.0.1",
-            "aria-query": "5.1.3",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.5.0",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "aria-query": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-          "dev": true,
-          "requires": {
-            "deep-equal": "^2.0.5"
-          }
-        },
-        "pretty-format": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        }
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@tootallnate/once": {
@@ -33308,12 +33050,6 @@
       "dev": true,
       "optional": true
     },
-    "@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
     "@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -33326,36 +33062,10 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
     },
-    "@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
     "@types/send": {
@@ -35421,12 +35131,6 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
-    },
     "clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -35556,6 +35260,12 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -36148,12 +35858,6 @@
         }
       }
     },
-    "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
-    },
     "cwd": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -36280,40 +35984,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "requires": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -36864,31 +36534,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
-    },
-    "es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
     },
     "es-iterator-helpers": {
       "version": "1.4.0",
@@ -38823,16 +38468,6 @@
       "dev": true,
       "requires": {
         "is-relative": "^0.1.0"
-      }
-    },
-    "is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "requires": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
       }
     },
     "is-array-buffer": {
@@ -42917,16 +42552,6 @@
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      }
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -43829,22 +43454,18 @@
       }
     },
     "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true
     },
     "react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       }
     },
     "react-is": {
@@ -43853,13 +43474,13 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-tooltip": {
-      "version": "5.30.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
-      "integrity": "sha512-1lSPLQXuVooePxadUpmcwLgOsF1mIty7UZTJ9XnyfX4drOzStYs4JMXnazcDLguQr41W5OUZddOp9kfvArdpEQ==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.8.tgz",
+      "integrity": "sha512-VPjtBPyoFwq72QVE6GYB/LtfEg/mnFBHqL0nD0oNNmjH8EZYFyBwgnFKNCOp5zCte45k1weXjKc0wXE6NICpfg==",
       "dev": true,
       "requires": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
+        "@floating-ui/dom": "1.7.6",
+        "clsx": "2.1.1"
       }
     },
     "read-package-up": {
@@ -44292,13 +43913,10 @@
       }
     },
     "scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true
     },
     "schema-utils": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "@eslint/js": "^9.39.5",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/react": "^14.3.1",
+    "@testing-library/react": "16.3.2",
     "babel-loader": "^10.1.1",
     "commitizen": "^4.3.2",
     "concurrently": "^10.0.3",
@@ -65,9 +66,9 @@
     "lint-staged": "^17.1.0",
     "prettier": "^3.9.6",
     "puppeteer-core": "^25.3.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-tooltip": "^5.30.1",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-tooltip": "6.0.8",
     "semantic-release": "^24.2.9",
     "style-loader": "^4.0.0",
     "web-ext": "^8.10.0",
@@ -76,7 +77,7 @@
     "webpack-dev-server": "^5.2.6"
   },
   "dependencies": {
-    "prop-types": "^15.7.2",
+    "prop-types": "15.8.1",
     "range-at-index": "^1.0.4"
   },
   "config": {

--- a/spec/WarningHighlightSpec.test.js
+++ b/spec/WarningHighlightSpec.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import WarningHighlight from '../src/components/WarningHighlight.js';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 describe('<WarningHighlight/>', () => {
   const testProps = {
@@ -25,6 +25,7 @@ describe('<WarningHighlight/>', () => {
           width: 25,
           height: 15,
         }}
+        number={3}
         message={testProps.message}
       />,
     );
@@ -41,7 +42,19 @@ describe('<WarningHighlight/>', () => {
     expect(jnsHighlights).toHaveLength(1);
     const jnsHighlight = jnsHighlights[0];
     expect(jnsHighlight.tagName).toEqual('DIV');
+    expect(jnsHighlight.dataset.tooltipId).toEqual('jns-highlight-3');
     expect(jnsHighlight.dataset.tooltipContent).toEqual('test-message');
     expect(jnsHighlight).toHaveStyle('left: 10px; height: 3px; width: 25px;');
+  });
+
+  it('should show the warning message in its tooltip', async () => {
+    const jnsHighlight = screen.getByTestId('jns-highlight');
+
+    fireEvent.mouseEnter(jnsHighlight);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveAttribute('id', 'jns-highlight-3');
+    expect(tooltip).toHaveClass('jns-tooltip');
+    expect(tooltip).toHaveTextContent('test-message');
   });
 });

--- a/spec/WarningMessagesSpec.test.js
+++ b/spec/WarningMessagesSpec.test.js
@@ -10,7 +10,7 @@ describe('WARNING_MESSAGES', () => {
     return (
       str &&
       /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-        str
+        str,
       )
     );
   }
@@ -37,7 +37,7 @@ describe('WARNING_MESSAGES', () => {
         describe('the pattern', () => {
           it('should be present', () => {
             expect(
-              Object.prototype.hasOwnProperty.call(warning, 'pattern')
+              Object.prototype.hasOwnProperty.call(warning, 'pattern'),
             ).toBeTruthy();
           });
 
@@ -57,7 +57,7 @@ describe('WARNING_MESSAGES', () => {
         describe('the source', () => {
           it('should be present', () => {
             expect(
-              Object.prototype.hasOwnProperty.call(warning, 'source')
+              Object.prototype.hasOwnProperty.call(warning, 'source'),
             ).toBeTruthy();
           });
 
@@ -73,7 +73,7 @@ describe('WARNING_MESSAGES', () => {
         describe('the message', () => {
           it('should be present', () => {
             expect(
-              Object.prototype.hasOwnProperty.call(warning, 'message')
+              Object.prototype.hasOwnProperty.call(warning, 'message'),
             ).toBeTruthy();
           });
 
@@ -86,7 +86,7 @@ describe('WARNING_MESSAGES', () => {
             expect(findIndexOfFirstNonASCIIChar(warning.message)).toEqual(-1);
           });
         });
-      }
+      },
     );
   });
 });

--- a/spec/setupTests.js
+++ b/spec/setupTests.js
@@ -1,5 +1,15 @@
 import '@testing-library/jest-dom';
 
+class ResizeObserver {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserver;
+
 // Work-around for jsdom not supporting offsetParent
 // https://github.com/jsdom/jsdom/issues/1261
 Object.defineProperty(HTMLElement.prototype, 'offsetParent', {

--- a/src/components/JustNotSorry.js
+++ b/src/components/JustNotSorry.js
@@ -23,7 +23,7 @@ const JustNotSorry = ({
   const applyEventListeners = ({ target }) => {
     const searchHandler = Util.debounce(
       () => showWarnings(target),
-      Util.WAIT_TIME
+      Util.WAIT_TIME,
     );
     onEvents.map((onEvent) => target.addEventListener(onEvent, searchHandler));
     target.addEventListener('blur', hideWarnings);

--- a/src/components/Warning.js
+++ b/src/components/Warning.js
@@ -16,7 +16,7 @@ export default function Warning(props) {
         message={props.message}
         container={props.textArea}
         bounds={clientRects[i]}
-      />
+      />,
     );
   }
   return <div data-testid="jns-warning">{highlights}</div>;

--- a/src/components/WarningHighlight.js
+++ b/src/components/WarningHighlight.js
@@ -4,9 +4,7 @@ import { Tooltip } from 'react-tooltip';
 const YPOS_ADJUSTMENT = 3;
 function calculatePosition(container, bounds) {
   return {
-    top: `${
-        bounds.top + bounds.height - container.top - YPOS_ADJUSTMENT
-    }px`,
+    top: `${bounds.top + bounds.height - container.top - YPOS_ADJUSTMENT}px`,
     left: `${bounds.left - container.left}px`,
     width: `${bounds.width}px`,
     height: `${bounds.height * 0.2}px`,
@@ -15,18 +13,18 @@ function calculatePosition(container, bounds) {
 
 export default function Highlight({ number, message, container, bounds }) {
   return (
-      <div
-          data-testid="jns-highlight"
-          className="jns-highlight"
-          data-tooltip-id={`jns-highlight-${number}`}
-          style={calculatePosition(container, bounds)}
-          data-tooltip-content={message}
-      >
-        <Tooltip
-            className="jns-tooltip"
-            id={`jns-highlight-${number}`}
-            float={true}
-        />
-      </div>
+    <div
+      data-testid="jns-highlight"
+      className="jns-highlight"
+      data-tooltip-id={`jns-highlight-${number}`}
+      style={calculatePosition(container, bounds)}
+      data-tooltip-content={message}
+    >
+      <Tooltip
+        className="jns-tooltip"
+        id={`jns-highlight-${number}`}
+        float={true}
+      />
+    </div>
   );
 }

--- a/src/helpers/RangeFinder.js
+++ b/src/helpers/RangeFinder.js
@@ -5,7 +5,7 @@ export function calculateWarnings(target, patternsToFind) {
   let nextNode;
   const textNodeIterator = document.createNodeIterator(
     target,
-    NodeFilter.SHOW_TEXT
+    NodeFilter.SHOW_TEXT,
   );
   while ((nextNode = textNodeIterator.nextNode()) !== null) {
     ranges.push(
@@ -14,7 +14,7 @@ export function calculateWarnings(target, patternsToFind) {
           message: pattern.message,
           rangeToHighlight: range,
         }));
-      })
+      }),
     );
   }
   return ranges;

--- a/src/index.js
+++ b/src/index.js
@@ -14,5 +14,5 @@ ReactDOM.hydrateRoot(
   <JustNotSorry
     phrases={MESSAGE_PATTERNS}
     onEvents={['input', 'focus', 'cut']}
-  />
+  />,
 );


### PR DESCRIPTION
## Summary

- upgrade React and React DOM to 19.2.7, react-tooltip to 6.0.8, and prop-types to 15.8.1
- align Testing Library with the React 19-compatible 16.3.2 release required by prerequisite issue #194
- add tooltip interaction coverage while preserving warning content and highlight placement
- make Chrome E2E manifest setup deterministic and worktree-safe
- apply the repository's current Prettier formatting to files that blocked the quality gate

## Why

Issue #195 upgrades the extension UI dependencies without intentionally changing warning, options, content-editable, public API, or manifest behavior. The merged prerequisite still used Testing Library 14.3.1, whose peer range only supports React 18, so the dependency graph also needed the 16.3.2 version specified by #194.

The E2E suite additionally exposed an asynchronous manifest rewrite and a repository-name-specific file match. Awaiting setup/teardown and using a worktree-safe test-page match makes the generated Chrome extension smoke test reliable.

## Validation

- `npm test -- --runInBand` — 254 tests passed across 7 suites
- `npm run lint:check`
- `npm run format:check`
- `npm run build`
- `npm run e2e` — 4 Chrome E2E/performance tests passed
- dependency tree validated with `npm ls`

Firefox smoke testing is not applicable to the unchanged Chrome MV3 manifest: Firefox rejects its `background.service_worker` field and requires a Gecko extension ID.

Closes #195
